### PR TITLE
style: rename `at` and `rt` to `access token` and `refresh token`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,8 +18,8 @@ TYPEORM_MIGRATIONS=dist/common/db/migrations/*.js
 TYPEORM_SEEDING_FACTORIES=dist/common/db/factories/**/*.js
 TYPEORM_SEEDING_SEEDS=dist/common/db/seeds/**/*.js
 
-AT_SECRET=at-secretKey
-RT_SECRET=rt_secretKey
+ACCESS_TOKEN_SECRET=at-secretKey
+REFRESH_TOKEN_SECRET=rt_secretKey
 AT_TOKEN_EXPIRATION_TIME=15m
 RT_TOKEN_EXPIRATION_TIME=1d
 

--- a/src/api/auth/auth.controller.ts
+++ b/src/api/auth/auth.controller.ts
@@ -14,8 +14,8 @@ import { ApiBearerAuth, ApiTags } from "@nestjs/swagger";
 import { GetCurrentUserId } from "../../common/decorators/get-current-user-id.decorator";
 import { GetCurrentUser } from "../../common/decorators/get-current-user.decorator";
 import { Public } from "../../common/decorators/public.decorator";
-import { AtGuard } from "../../common/guards/at.guard";
-import { RtGuard } from "../../common/guards/rt.guard";
+import { AccessTokenGuard } from "../../common/guards/access-token.guard";
+import { RefreshTokenGuard } from "../../common/guards/refresh-token.guard";
 import { AuthService } from "./auth.service";
 import { LoginDto } from "./dtos/login.dto";
 import { RegisterDTO } from "./dtos/register.dto";
@@ -45,7 +45,7 @@ export class AuthController implements IAuthController {
     return this.authService.login(loginDto);
   }
 
-  @UseGuards(AtGuard)
+  @UseGuards(AccessTokenGuard)
   @Post("logout")
   @HttpCode(HttpStatus.OK)
   async logout(@GetCurrentUserId() userId: string): Promise<void> {
@@ -53,7 +53,7 @@ export class AuthController implements IAuthController {
   }
 
   @Public()
-  @UseGuards(RtGuard)
+  @UseGuards(RefreshTokenGuard)
   @Post("token")
   @HttpCode(HttpStatus.OK)
   async refreshToken(@GetCurrentUser() user: TGetCurrentUser): Promise<Tokens> {

--- a/src/api/auth/auth.module.ts
+++ b/src/api/auth/auth.module.ts
@@ -5,15 +5,15 @@ import { User } from "../user/entities/user.entity";
 import { AuthController } from "./auth.controller";
 import { AuthService } from "./auth.service";
 import { jwtConstants } from "./constants/constants";
-import { AtStrategy } from "./strategies/at.strategy";
-import { RtStrategy } from "./strategies/rt.strategy";
+import { AccessTokenStrategy } from "./strategies/access-token.strategy";
+import { RefreshTokenStrategy } from "./strategies/refresh-token.strategy";
 
 @Module({
   imports: [
-    JwtModule.register({ secret: jwtConstants.at_secret }),
+    JwtModule.register({ secret: jwtConstants.access_token_secret }),
     TypeOrmModule.forFeature([User]),
   ],
   controllers: [AuthController],
-  providers: [AuthService, RtStrategy, AtStrategy],
+  providers: [AuthService, RefreshTokenStrategy, AccessTokenStrategy],
 })
 export class AuthModule {}

--- a/src/api/auth/auth.service.ts
+++ b/src/api/auth/auth.service.ts
@@ -114,11 +114,11 @@ export class AuthService implements IAuthService {
 
     const [at, rt] = await Promise.all([
       this.jwtService.signAsync(jwtPayload, {
-        secret: jwtConstants.at_secret,
+        secret: jwtConstants.access_token_secret,
         expiresIn: process.env.AT_TOKEN_EXPIRATION_TIME,
       }),
       this.jwtService.signAsync(jwtPayload, {
-        secret: jwtConstants.rt_secret,
+        secret: jwtConstants.refresh_token_secret,
         expiresIn: process.env.RT_TOKEN_EXPIRATION_TIME,
       }),
     ]);

--- a/src/api/auth/constants/constants.ts
+++ b/src/api/auth/constants/constants.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 
 export const jwtConstants = {
-  at_secret: process.env.AT_SECRET,
-  rt_secret: process.env.RT_SECRET,
+  access_token_secret: process.env.ACCESS_TOKEN_SECRET,
+  refresh_token_secret: process.env.REFRESH_TOKEN_SECRET,
 };

--- a/src/api/auth/strategies/access-token.strategy.ts
+++ b/src/api/auth/strategies/access-token.strategy.ts
@@ -3,19 +3,19 @@ import { PassportStrategy } from "@nestjs/passport";
 import { InjectRepository } from "@nestjs/typeorm";
 import { ExtractJwt, Strategy } from "passport-jwt";
 import { Repository } from "typeorm";
-import { User } from "../../../api/user/entities/user.entity";
+import { User } from "../../user/entities/user.entity";
 import { jwtConstants } from "../constants/constants";
 import { JwtPayload } from "../interfaces/jwt-payload.inteface";
 
 @Injectable()
-export class AtStrategy extends PassportStrategy(Strategy, "jwt") {
+export class AccessTokenStrategy extends PassportStrategy(Strategy, "jwt") {
   constructor(
     @InjectRepository(User)
     private userRepository: Repository<User>,
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-      secretOrKey: jwtConstants.at_secret,
+      secretOrKey: jwtConstants.access_token_secret,
     });
   }
 

--- a/src/api/auth/strategies/refresh-token.strategy.ts
+++ b/src/api/auth/strategies/refresh-token.strategy.ts
@@ -6,11 +6,11 @@ import { jwtConstants } from "../constants/constants";
 import { JwtPayload } from "../interfaces/jwt-payload.inteface";
 
 @Injectable()
-export class RtStrategy extends PassportStrategy(Strategy, "jwt-refresh") {
+export class RefreshTokenStrategy extends PassportStrategy(Strategy, "jwt-refresh") {
   constructor() {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-      secretOrKey: jwtConstants.rt_secret,
+      secretOrKey: jwtConstants.refresh_token_secret,
       passReqToCallback: true,
     });
   }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,7 +12,7 @@ import { UserModule } from "./api/user/user.module";
 import { AppController } from "./app.controller";
 import { AppService } from "./app.service";
 import { config } from "./common/db/dataSource/data-source.config";
-import { AtGuard } from "./common/guards/at.guard";
+import { AccessTokenGuard } from "./common/guards/access-token.guard";
 import { MailService } from "./services/mail/mail.service";
 
 @Module({
@@ -46,6 +46,11 @@ import { MailService } from "./services/mail/mail.service";
     UserModule,
   ],
   controllers: [AppController],
-  providers: [{ provide: APP_GUARD, useClass: AtGuard }, AppService, MailService, Logger],
+  providers: [
+    { provide: APP_GUARD, useClass: AccessTokenGuard },
+    AppService,
+    MailService,
+    Logger,
+  ],
 })
 export class AppModule {}

--- a/src/common/guards/access-token.guard.ts
+++ b/src/common/guards/access-token.guard.ts
@@ -3,7 +3,7 @@ import { Reflector } from "@nestjs/core";
 import { AuthGuard } from "@nestjs/passport";
 
 @Injectable()
-export class AtGuard extends AuthGuard("jwt") {
+export class AccessTokenGuard extends AuthGuard("jwt") {
   constructor(protected reflector: Reflector) {
     super();
   }

--- a/src/common/guards/refresh-token.guard.ts
+++ b/src/common/guards/refresh-token.guard.ts
@@ -1,6 +1,6 @@
 import { AuthGuard } from "@nestjs/passport";
 
-export class RtGuard extends AuthGuard("jwt-refresh") {
+export class RefreshTokenGuard extends AuthGuard("jwt-refresh") {
   constructor() {
     super();
   }


### PR DESCRIPTION
This PR renames the `at` and `rt` abbreviations to their full token names, as well as their corresponding imports.

Guards:
 - `at` guard -> `access-token` guard
 - `rt` guard -> `refresh-token` guard

Strategies:
 - `at` strategy -> `access-token` strategy
 - `rt` strategy -> `refresh-token` strategy

Environment variables
 - `AT_SECRET` -> `ACCESS_TOKEN_SECRET`
 - `RT_SECRET` -> `REFRESH_TOKEN_SECRET`

Constants:
 - `at_secret` -> `access_token_secret`
 - `rt_secret` -> `refresh_token_secret`