### PR TITLE
feature: enable URI versioning for API

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get, Logger } from "@nestjs/common";
+import { Controller, Get, Logger, VERSION_NEUTRAL, Version } from "@nestjs/common";
 import { AppService } from "./app.service";
+import { Public } from "./common/decorators/public.decorator";
 
 @Controller()
 export class AppController {
@@ -8,8 +9,19 @@ export class AppController {
     private logger: Logger,
   ) {}
 
+  @Version("1")
+  @Public()
   @Get()
   getHello(): string {
     return this.appService.getHello();
+  }
+
+  @Version("2")
+  @Public()
+  @Get()
+  getHelloV2() {
+    return {
+      message: `${this.appService.getHello()} from /api/v2`,
+    };
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,9 @@
-import { RequestMethod, ValidationPipe } from "@nestjs/common";
+import {
+  RequestMethod,
+  VERSION_NEUTRAL,
+  ValidationPipe,
+  VersioningType,
+} from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { apiReference } from "@scalar/nestjs-api-reference";
@@ -22,6 +27,10 @@ async function bootstrap() {
   );
   app.setGlobalPrefix("api", {
     exclude: [{ path: "/", method: RequestMethod.GET }],
+  });
+  app.enableVersioning({
+    type: VersioningType.URI,
+    defaultVersion: VERSION_NEUTRAL,
   });
 
   if (process.env.NODE_ENV !== "production") {


### PR DESCRIPTION
This PR enables API versioning using the URI version type.

### Usage

```js
// Controller version
@Version(1)
@Controller("users")
export class ExampleController {}

// Route version
@Version(2)
@Get("route")
exampleRoute() {}
```

### Request example

```bash
curl "domain.com/api/v1/users"
curl "domain.com/api/v2/route"
```