### PR TITLE
docs: add docs for comments DTOs

### DIFF
--- a/src/api/comments/dtos/create-comment.dto.ts
+++ b/src/api/comments/dtos/create-comment.dto.ts
@@ -1,16 +1,34 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { IsNotEmpty, IsOptional, IsString, IsUUID, MaxLength } from "class-validator";
 
 export class CreateCommentDto {
   @IsNotEmpty()
   @IsUUID()
+  @ApiProperty({
+    type: String,
+    description: "UUID of the room in which the note is created",
+    example: "1b87c96d-3240-4dbe-992f-36e56899b5fc",
+  })
   noteId: string;
 
   @IsNotEmpty()
   @IsString()
   @MaxLength(150)
+  @ApiProperty({
+    type: String,
+    description: "Note contents",
+    maxLength: 150,
+    example: "This is a note about the importance of writing.",
+  })
   content: string;
 
   @IsOptional()
   @IsUUID()
+  @ApiPropertyOptional({
+    type: String,
+    description: "UUID of the parent comment that the comment is replying to",
+    example: "1354f59a-1a53-4979-9089-857912c4d06d",
+    // nullable: true,
+  })
   parentId?: string;
 }

--- a/src/api/comments/dtos/update-comment.dto.ts
+++ b/src/api/comments/dtos/update-comment.dto.ts
@@ -1,8 +1,15 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { IsNotEmpty, IsString, IsUUID, MaxLength } from "class-validator";
 
 export class UpdateCommentDto {
   @IsNotEmpty()
   @IsString()
   @MaxLength(150)
+  @ApiProperty({
+    type: String,
+    description: "Note contents",
+    maxLength: 150,
+    example: "This is a note about the importance of writing.",
+  })
   content: string;
 }


### PR DESCRIPTION
This PR adds swagger property documentation for `CreateCommentDTO` and `UpdateCommentDto`.