### PR TITLE
feature: add return type interface for delete endpoints

### DIFF
--- a/src/common/interfaces/DeleteStatus.interface.ts
+++ b/src/common/interfaces/DeleteStatus.interface.ts
@@ -1,0 +1,9 @@
+import { ResourceType } from "../types/ResourceType";
+
+export interface IDeleteStatus {
+  success: boolean;
+  message: string;
+  resourceType: ResourceType;
+  resourceId?: string;
+  timestamp?: Date;
+}

--- a/src/common/types/ResourceType.ts
+++ b/src/common/types/ResourceType.ts
@@ -1,0 +1,1 @@
+export type ResourceType = "user" | "comment" | "note";


### PR DESCRIPTION
This PR adds a common interface to denote return types of delete endpoint functions.

### Example
```js
/* ... */
async delete(itemId: string): Promise<IDeleteStatus> {
  /* Implementation */

  return {
    success: true,
    message: "Item deleted successfully",
    resourceType: "note",
    resouceId: "1354f59a-1a53-4979-9089-857912c4d06d",
    timestamp: new Date()
  }
}
```