### PR TITLE
fix: use plural table name for comments entity

### DIFF
--- a/src/api/comments/entities/comment.entity.ts
+++ b/src/api/comments/entities/comment.entity.ts
@@ -3,7 +3,7 @@ import { User } from "src/api/user/entities/user.entity";
 import { AuditEntity } from "src/common/db/customBaseEntites/AuditEntity";
 import { Column, Entity, JoinColumn, ManyToOne, OneToOne } from "typeorm";
 
-@Entity()
+@Entity("comments")
 export class Comment extends AuditEntity {
   @Column({
     type: "varchar",


### PR DESCRIPTION
This PR sets the comment entity name to be plural. The table `comment` now shows up as `comments` in the database