### PR TITLE
style: remove unused imports with biome rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -12,7 +12,8 @@
         "noParameterAssign": "off"
       },
       "correctness": {
-        "noUnusedVariables": "error"
+        "noUnusedVariables": "error",
+        "noUnusedImports": "error"
       },
       "suspicious": {
         "noExplicitAny": "off",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"lint": "biome lint ./src",
 		"format": "biome format --write ./src",
 		"check": "biome check ./src",
+    "check:fix": "biome check --fix ./src",
 		"test": "jest",
 		"test:watch": "jest --watch",
 		"test:cov": "jest --coverage",

--- a/src/api/comments/dtos/update-comment.dto.ts
+++ b/src/api/comments/dtos/update-comment.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsNotEmpty, IsString, IsUUID, MaxLength } from "class-validator";
+import { IsNotEmpty, IsString, MaxLength } from "class-validator";
 
 export class UpdateCommentDto {
   @IsNotEmpty()

--- a/src/api/comments/entities/comment.entity.ts
+++ b/src/api/comments/entities/comment.entity.ts
@@ -1,7 +1,7 @@
 import { Note } from "src/api/notes/entities/note.entity";
 import { User } from "src/api/user/entities/user.entity";
 import { AuditEntity } from "src/common/db/customBaseEntites/AuditEntity";
-import { Column, Entity, JoinColumn, ManyToOne, OneToOne } from "typeorm";
+import { Column, Entity, JoinColumn, ManyToOne } from "typeorm";
 
 @Entity("comments")
 export class Comment extends AuditEntity {

--- a/src/api/notes/notes.controller.ts
+++ b/src/api/notes/notes.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Delete, Get, Patch, Post } from "@nestjs/common";
+import { Controller } from "@nestjs/common";
 
 // TODO: implement INotesController interface
 @Controller("notes")

--- a/src/api/notes/notes.service.ts
+++ b/src/api/notes/notes.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from "@nestjs/common";
-import { INotesService } from "./interfaces/notes.service.interface";
 
 // TODO: implement INotesService interface
 @Injectable()

--- a/src/api/rooms/entities/room-users.entity.ts
+++ b/src/api/rooms/entities/room-users.entity.ts
@@ -5,7 +5,6 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
-  OneToMany,
   PrimaryColumn,
 } from "typeorm";
 import { Roles } from "../enums/roles.enum";

--- a/src/api/user/entities/user.entity.ts
+++ b/src/api/user/entities/user.entity.ts
@@ -5,7 +5,6 @@ import { RoomUsers } from "src/api/rooms/entities/room-users.entity";
 import { Column, Entity, Index, OneToMany } from "typeorm";
 import { AuditEntity } from "../../../common/db/customBaseEntites/AuditEntity";
 import { UserRoles } from "../enums/roles.enum";
-import { UserGender } from "../enums/userGender.enum";
 
 @Entity("users")
 export class User extends AuditEntity {

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Logger, VERSION_NEUTRAL, Version } from "@nestjs/common";
+import { Controller, Get, Logger, Version } from "@nestjs/common";
 import { AppService } from "./app.service";
 import { Public } from "./common/decorators/public.decorator";
 

--- a/src/common/db/seeds/users/create-users.seed.ts
+++ b/src/common/db/seeds/users/create-users.seed.ts
@@ -2,7 +2,6 @@ import { Injectable } from "@nestjs/common";
 import { Seeder } from "nestjs-seeder";
 import { In } from "typeorm";
 import { User } from "../../../../api/user/entities/user.entity";
-import { UserGender } from "../../../../api/user/enums/userGender.enum";
 import AppDataSource from "../../dataSource/data-source.initialize";
 
 @Injectable()


### PR DESCRIPTION
This PR adds a the biome configuration rule `noUnusedImports`. It also adds a new npm script to clean up biome lint warnings.

### Usage

```bash
npm run check:fix
```

The unused imports were cleaned using said script.