### PR TITLE
docs: update README migration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ npx typeorm migration:create ./src/common/db/migrations/[filename]
 ```
 #### Instead of :
 ```bash
-npm run migration:create --FILE=[filename]
-# Example: npm run migration:create --FILE=UpdatePost
+npm run migration:create --name=[filename]
+# Example: npm run migration:create --name=UpdatePost
 ```
 
 ### .env file


### PR DESCRIPTION
This PR updates the README instructions with the correct flag for running migrations on MacOS.