### PR TITLE
refactor: rename password reset table

### DIFF
--- a/src/common/db/migrations/1745852551876-UpdateResetPassword.ts
+++ b/src/common/db/migrations/1745852551876-UpdateResetPassword.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateResetPassword1745852551876 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.renameTable("password-reset", "password_reset");
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.renameTable("password_reset", "password-reset");
+  }
+}


### PR DESCRIPTION
This PR renames the password reset table from `password-reset` -> `password_reset` for consistency