### PR TITLE
feature: add response classes for API error documentation

### DIFF
--- a/src/common/interfaces/ApiResponse.interface.ts
+++ b/src/common/interfaces/ApiResponse.interface.ts
@@ -1,0 +1,5 @@
+export type IApiResponse = {
+  statusCode: number;
+  error: string;
+  message?: string;
+};

--- a/src/common/interfaces/responses/bad-request.response.ts
+++ b/src/common/interfaces/responses/bad-request.response.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IApiResponse } from "../ApiResponse.interface";
+
+export class BadRequestResponse implements IApiResponse {
+  @ApiProperty({
+    type: Number,
+    description: "HTTP status code",
+    example: 400,
+  })
+  statusCode: number;
+
+  @ApiProperty({
+    type: String,
+    description: "HTTP method error",
+    example: "Bad Request",
+  })
+  error: string;
+
+  @ApiProperty({
+    type: String,
+    description: "Error message",
+    example: "Error processing request",
+  })
+  message: string;
+}

--- a/src/common/interfaces/responses/internal-error.response.ts
+++ b/src/common/interfaces/responses/internal-error.response.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IApiResponse } from "../ApiResponse.interface";
+
+export class InternalErrorResponse implements IApiResponse {
+  @ApiProperty({
+    type: Number,
+    description: "HTTP status code",
+    example: 500,
+  })
+  statusCode: number;
+
+  @ApiProperty({
+    type: String,
+    description: "HTTP method error",
+    example: "Internal Server Error",
+  })
+  error: string;
+}

--- a/src/common/interfaces/responses/not-found.response.ts
+++ b/src/common/interfaces/responses/not-found.response.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IApiResponse } from "../ApiResponse.interface";
+
+export class NotFoundResponse implements IApiResponse {
+  @ApiProperty({
+    type: Number,
+    description: "HTTP status code",
+    example: 404,
+  })
+  statusCode: number;
+
+  @ApiProperty({
+    type: String,
+    description: "HTTP method error",
+    example: "Not Found",
+  })
+  error: string;
+
+  @ApiProperty({
+    type: String,
+    description: "Error description",
+    example: "Resource not Found",
+  })
+  message: string;
+}

--- a/src/common/interfaces/responses/unauthorized.response.ts
+++ b/src/common/interfaces/responses/unauthorized.response.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IApiResponse } from "../ApiResponse.interface";
+
+export class UnauthorizedResponse implements IApiResponse {
+  @ApiProperty({
+    type: Number,
+    description: "HTTP status code",
+    example: 401,
+  })
+  statusCode: number;
+
+  @ApiProperty({
+    type: String,
+    description: "HTTP method error",
+    example: "Unauthorized",
+  })
+  error: string;
+}


### PR DESCRIPTION
This PR creates classes used for documenting returned data from errors. These classes document the structure and example data returned by the API in case of errors including:

- `404 Not Found` errors (`NotFoundResponse`)
- `401 Unauthorized` errors (`UnauthorizedResponse`)
- `400 Bad Request` errors (`BadRequestResponse`)
- `500 Internal Server Error` errors (`InternalErrorResponse`)


### Usage

```js
@ApiNotFoundResponse({
	description: "404 error if <entity> is not found",
	type: NotFoundResponse
})
@ApiUnauthorizedResponse({
	description: "401 error if no bearer token is provided",
	type: UnauthorizedResponse
})
route(param: any) {}
```