### PR TITLE
docs: add docs for comments endpoint

### DIFF
--- a/src/api/comments/comments.controller.ts
+++ b/src/api/comments/comments.controller.ts
@@ -1,5 +1,19 @@
-import { Controller, Get, ParseUUIDPipe, Query } from "@nestjs/common";
-import { ApiBearerAuth, ApiNotFoundResponse, ApiOkResponse, ApiTags } from "@nestjs/swagger";
+import { Controller, Delete, Get, ParseUUIDPipe, Patch, Post, Query } from "@nestjs/common";
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from "@nestjs/swagger";
+import { IDeleteStatus } from "src/common/interfaces/DeleteStatus.interface";
+import { BadRequestResponse } from "src/common/interfaces/responses/bad-request.response";
+import { DeletedResponse } from "src/common/interfaces/responses/deleted.response";
+import { NotFoundResponse } from "src/common/interfaces/responses/not-found.response";
+import { UnauthorizedResponse } from "src/common/interfaces/responses/unauthorized.response";
 import { CommentsService } from "./comments.service";
 import { CreateCommentDto } from "./dtos/create-comment.dto";
 import { UpdateCommentDto } from "./dtos/update-comment.dto";
@@ -12,26 +26,92 @@ import { ICommentsController } from "./interfaces/comments.controller.interface"
 export class CommentsController implements ICommentsController {
   constructor(private commentsService: CommentsService) {}
 
-  @Get()
+  @ApiOperation({
+    summary: "Get all comments for a note",
+    description: "Retrieves all comments associated with the specified note ID",
+  })
   @ApiOkResponse({
     description: "A 200 response if the comments are found successfully",
     type: Comment,
     isArray: true,
   })
-  @ApiNotFoundResponse({ description: "A 404 error if the note doesn't exist" })
-  findAll(@Query("noteId", new ParseUUIDPipe()) noteId: string): Promise<Comment[]> {
+  @ApiUnauthorizedResponse({
+    description: "A 401 error if no bearer token is provided",
+    type: UnauthorizedResponse,
+  })
+  @ApiNotFoundResponse({
+    description: "A 404 error if the note doesn't exist",
+    type: NotFoundResponse,
+  })
+  @Get()
+  async findAll(@Query("noteId", new ParseUUIDPipe()) noteId: string): Promise<Comment[]> {
     return this.commentsService.findComments(noteId);
   }
 
-  create(userId: string, body: CreateCommentDto): Promise<Comment> {
+  @ApiOperation({
+    summary: "Create a new comment",
+    description: "Creates a new comment associated with the specified note ID",
+  })
+  @ApiCreatedResponse({
+    description: "A 201 response if the comment is created successfully",
+    type: Comment,
+  })
+  @ApiUnauthorizedResponse({
+    description: "A 401 error if no bearer token is provided",
+    type: UnauthorizedResponse,
+  })
+  @ApiNotFoundResponse({
+    description: "A 404 error if the note doesn't exist",
+    type: NotFoundResponse,
+  })
+  @Post()
+  async create(userId: string, body: CreateCommentDto): Promise<Comment> {
     throw new Error("Method not implemented.");
   }
 
-  update(commendId: string, body: UpdateCommentDto): Promise<Comment> {
+  @ApiOperation({
+    summary: "Update a comment",
+    description: "Updates an existing comment associated with the specified comment ID",
+  })
+  @ApiOkResponse({
+    description: "A 200 response if the comment is updated successfully",
+    type: Comment,
+  })
+  @ApiUnauthorizedResponse({
+    description: "A 401 error if no bearer token is provided",
+    type: UnauthorizedResponse,
+  })
+  @ApiNotFoundResponse({
+    description: "A 404 error if the comment doesn't exist",
+    type: NotFoundResponse,
+  })
+  @ApiBadRequestResponse({
+    description: "A 400 error if the request body is invalid",
+    type: BadRequestResponse,
+  })
+  @Patch(":commentId")
+  async update(commendId: string, body: UpdateCommentDto): Promise<Comment> {
     throw new Error("Method not implemented.");
   }
 
-  delete(commentid: string): Promise<boolean> {
+  @ApiOperation({
+    summary: "Delete a comment",
+    description: "Deletes an existing comment associated with the specified comment ID",
+  })
+  @ApiOkResponse({
+    description: "A 200 response if the comment is deleted successfully",
+    type: DeletedResponse,
+  })
+  @ApiNotFoundResponse({
+    description: "A 404 error if the comment doesn't exist",
+    type: NotFoundResponse,
+  })
+  @ApiUnauthorizedResponse({
+    description: "A 401 error if no bearer token is provided",
+    type: UnauthorizedResponse,
+  })
+  @Delete(":commentId")
+  async delete(commentid: string): Promise<IDeleteStatus> {
     throw new Error("Method not implemented.");
   }
 }

--- a/src/api/comments/interfaces/comments.controller.interface.ts
+++ b/src/api/comments/interfaces/comments.controller.interface.ts
@@ -1,3 +1,4 @@
+import { IDeleteStatus } from "src/common/interfaces/DeleteStatus.interface";
 import { CreateCommentDto } from "../dtos/create-comment.dto";
 import { UpdateCommentDto } from "../dtos/update-comment.dto";
 import { Comment } from "../entities/comment.entity";
@@ -9,5 +10,5 @@ export interface ICommentsController {
 
   update(commendId: string, body: UpdateCommentDto): Promise<Comment>;
 
-  delete(commentid: string): Promise<boolean>;
+  delete(commentId: string): Promise<IDeleteStatus>;
 }

--- a/src/common/interfaces/responses/deleted.response.ts
+++ b/src/common/interfaces/responses/deleted.response.ts
@@ -1,0 +1,40 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { ResourceType } from "src/common/types/ResourceType";
+import { IDeleteStatus } from "../DeleteStatus.interface";
+
+export class DeletedResponse implements IDeleteStatus {
+  @ApiProperty({
+    type: Boolean,
+    description: "Indicates if the request was successful",
+    example: true,
+  })
+  success: boolean;
+
+  @ApiProperty({
+    type: String,
+    description: "Message indicating the status of the deletion",
+    example: "Resource deleted successfully",
+  })
+  message: string;
+
+  @ApiProperty({
+    type: String,
+    description: "The type of resource that was deleted",
+    example: "note",
+  })
+  resourceType: ResourceType;
+
+  @ApiProperty({
+    type: String,
+    description: "The unique identifier of the deleted resource",
+    example: "123e4567-e89b-12d3-a456-426614174000",
+  })
+  resourceId?: string;
+
+  @ApiProperty({
+    type: Date,
+    description: "Timestamp of when the deletion occurred",
+    example: "2023-10-01T12:00:00Z",
+  })
+  timestamp?: Date;
+}


### PR DESCRIPTION
This PR adds documentation for all routes within the comments endpoint. It also adds the `DeleteStatus` class for documenting the structure & example data for delete endpoints.