### PR TITLE
feature: add error handling for TypeORM errors in comments service

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"migration:revert": "npm run typeorm -- migration:revert"
 	},
 	"dependencies": {
+		"@maxmorozoff/try-catch-tuple": "^0.1.2",
 		"@nestjs-modules/mailer": "^1.8.1",
 		"@nestjs/common": "^9.0.0",
 		"@nestjs/config": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@maxmorozoff/try-catch-tuple':
+        specifier: ^0.1.2
+        version: 0.1.2(typescript@4.9.5)
       '@nestjs-modules/mailer':
         specifier: ^1.8.1
         version: 1.11.2(@nestjs/common@9.4.3(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@9.4.3)(nodemailer@6.10.1)
@@ -700,6 +703,14 @@ packages:
   '@mapbox/node-pre-gyp@1.0.11':
     resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
     hasBin: true
+
+  '@maxmorozoff/try-catch-tuple@0.1.2':
+    resolution: {integrity: sha512-stFwucLpAkJPkLIlBGsXB/Q9A3kSTFoioqqlz7V5r6pwsysQ1/+vpVKEutmbjSztoIOdy+iTn/iSSKyJXb+ebQ==}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@nestjs-modules/mailer@1.11.2':
     resolution: {integrity: sha512-k07wyKbtCzxWMm6IqGwcGIisnXD/6sneGvUR8rBBZbxtLn1HE1FLGyiaXBrPui/0K7W41aS9x9jAIhfTawtlUg==}
@@ -5296,6 +5307,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@maxmorozoff/try-catch-tuple@0.1.2(typescript@4.9.5)':
+    optionalDependencies:
+      typescript: 4.9.5
 
   '@nestjs-modules/mailer@1.11.2(@nestjs/common@9.4.3(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@9.4.3)(nodemailer@6.10.1)':
     dependencies:

--- a/src/api/comments/comments.service.ts
+++ b/src/api/comments/comments.service.ts
@@ -21,6 +21,7 @@ export class CommentsService implements ICommentsService {
    * @param commentId - Unique comment UUID
    * @returns Promise that resolves to the found comment
    * @throws {NotFoundException} - If no comment is found with the given UUID
+   * @throws {InternalServerErrorException} - If there was an error processing the request
    */
   async findById(commentId: string): Promise<Comment> {
     const [comment, error] = await tryCatch(
@@ -41,6 +42,7 @@ export class CommentsService implements ICommentsService {
    * @param noteId - Unique note UUID
    * @returns Promise that resolves to the found comments array
    * @throws {NotFoundException} - If no note is found with the given UUID
+   * @throws {InternalServerErrorException} - If there was an error processing the request
    */
   async findComments(noteId: string): Promise<Comment[]> {
     const note = await this.notesService.findById(noteId);
@@ -61,6 +63,7 @@ export class CommentsService implements ICommentsService {
    * @param payload - The required data to create a comment
    * @returns Promise that resolves to the created comment
    * @throws {NotFoundException} - If no note is found with the given UUID
+   * @throws {InternalServerErrorException} - If there was an error processing the request
    */
   async createComment(payload: CreateCommentDto): Promise<Comment> {
     const note = await this.notesService.findById(payload.noteId);
@@ -82,6 +85,7 @@ export class CommentsService implements ICommentsService {
    * @param payload - Given attributes of the comment to update
    * @returns Promise that resolves to the updated comment
    * @throws {NotFoundException} - If no comment is found with the given UUID
+   * @throws {InternalServerErrorException} - If there was an error processing the request
    */
   async updateComment(commentId: string, payload: UpdateCommentDto): Promise<Comment> {
     const comment = await this.findById(commentId);


### PR DESCRIPTION
This PR adds error handling in case of TypeORM failing to execute functions for the comments service. It uses the `@maxmorozoff/try-catch-tuple` package which uses error-as-value style error handling.

### Usage

```js
const [data, error] = tryCatch(functionOrCallback);
const [data2, error2] = await tryCatch(functionOrCallback); // for async operations
//     ^ Easy to rename with destructuring

if (error) throw new Error(error.message);
```

### Types

```js
const [data, error] = tryCatch(functionOrCallback);
// data: T | null
// error: Error | null
```