### PR TITLE
refactor: update refresh token route

### DIFF
--- a/src/api/auth/auth.controller.ts
+++ b/src/api/auth/auth.controller.ts
@@ -12,15 +12,13 @@ import {
 } from "@nestjs/common";
 import { ApiBearerAuth, ApiTags } from "@nestjs/swagger";
 import { GetCurrentUserId } from "../../common/decorators/get-current-user-id.decorator";
-import { GetCurrentUser } from "../../common/decorators/get-current-user.decorator";
 import { Public } from "../../common/decorators/public.decorator";
 import { AccessTokenGuard } from "../../common/guards/access-token.guard";
-import { RefreshTokenGuard } from "../../common/guards/refresh-token.guard";
 import { AuthService } from "./auth.service";
 import { LoginDto } from "./dtos/login.dto";
+import { RefreshTokenDto } from "./dtos/refresh-token.dto";
 import { RegisterDTO } from "./dtos/register.dto";
 import { IAuthController } from "./interfaces/auth.controller.interface";
-import { TGetCurrentUser } from "./types";
 import { Tokens } from "./types/tokens.types";
 
 @ApiBearerAuth()
@@ -53,10 +51,9 @@ export class AuthController implements IAuthController {
   }
 
   @Public()
-  @UseGuards(RefreshTokenGuard)
-  @Post("token")
+  @Post("refresh-token")
   @HttpCode(HttpStatus.OK)
-  async refreshToken(@GetCurrentUser() user: TGetCurrentUser): Promise<Tokens> {
-    return await this.authService.refreshToken(user.id, user.refreshToken);
+  async refreshToken(@Body() body: RefreshTokenDto): Promise<Tokens> {
+    return await this.authService.refreshToken(body);
   }
 }

--- a/src/api/auth/dtos/refresh-token.dto.ts
+++ b/src/api/auth/dtos/refresh-token.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from "class-validator";
+
+export class RefreshTokenDto {
+  @IsNotEmpty()
+  @IsString()
+  refreshToken: string;
+}

--- a/src/api/auth/interfaces/auth.controller.interface.ts
+++ b/src/api/auth/interfaces/auth.controller.interface.ts
@@ -1,10 +1,11 @@
 import { LoginDto } from "../dtos/login.dto";
+import { RefreshTokenDto } from "../dtos/refresh-token.dto";
 import { RegisterDTO } from "../dtos/register.dto";
-import { TGetCurrentUser, Tokens } from "../types";
+import { Tokens } from "../types";
 
 export interface IAuthController {
   register: (body: RegisterDTO) => Promise<Tokens>;
   login: (body: LoginDto) => Promise<Tokens>;
   logout: (user: string) => Promise<void>;
-  refreshToken: (user: TGetCurrentUser, refreshToken: string) => Promise<Tokens>;
+  refreshToken: (body: RefreshTokenDto) => Promise<Tokens>;
 }

--- a/src/api/auth/interfaces/auth.service.interface.ts
+++ b/src/api/auth/interfaces/auth.service.interface.ts
@@ -1,4 +1,5 @@
 import { LoginDto } from "../dtos/login.dto";
+import { RefreshTokenDto } from "../dtos/refresh-token.dto";
 import { RegisterDTO } from "../dtos/register.dto";
 import { Tokens } from "../types/tokens.types";
 
@@ -6,5 +7,5 @@ export interface IAuthService {
   signup: (payload: RegisterDTO) => Promise<Tokens>;
   login: (payload: LoginDto) => Promise<Tokens>;
   logout: (user: string) => Promise<void>;
-  refreshToken: (user: string, refreshToken: string) => Promise<Tokens>;
+  refreshToken: (payoad: RefreshTokenDto) => Promise<Tokens>;
 }


### PR DESCRIPTION
This PR updates the refresh token route logic in the auth endpoint. It:

- Gets the refresh token from the request body instead of the
Authorization header
- Changes route name from `token` -> `refresh-token`