### PR TITLE
refactor: update reset password url in email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 #it can be localhost, development, staging, production
 NODE_ENV=localhost
 APP_URL=http://localhost:3000/api
+FRONT_APP_URL=http://localhost:8000/
 PORT=3000
 
 JWT_SECRET=secret

--- a/src/api/user/users.service.ts
+++ b/src/api/user/users.service.ts
@@ -129,7 +129,7 @@ export class UsersService implements IUsersService {
     expiresAt.setHours(expiresAt.getHours() + 1);
 
     /**Send Email for forgotPassword*/
-    const emailDetails = { user: user.email, token: token };
+    const emailDetails = { user, token: token };
     this.emitter.emit("forgotPasswordMail", emailDetails);
 
     await this.passwordRepository.save({

--- a/src/common/interfaces/ForgotPasswordEmail.interface.ts
+++ b/src/common/interfaces/ForgotPasswordEmail.interface.ts
@@ -1,0 +1,6 @@
+import { User } from "src/api/user/entities/user.entity";
+
+export interface ForgotPasswordEmail {
+  user: User;
+  token: string;
+}

--- a/src/services/mail/mail.service.ts
+++ b/src/services/mail/mail.service.ts
@@ -1,23 +1,24 @@
 import { MailerService } from "@nestjs-modules/mailer";
 import { Inject, Injectable } from "@nestjs/common";
+import { ForgotPasswordEmail } from "src/common/interfaces/ForgotPasswordEmail.interface";
 
 @Injectable()
 export class MailService {
   constructor(@Inject(MailerService) private readonly mailerService: MailerService) {}
 
   readonly fromEmail: string = process.env.SENDER_MAIL;
-  readonly FRONT_APP_URL: string = process.env.APP_URL;
+  readonly FRONT_APP_URL: string = process.env.FRONT_APP_URL;
 
-  public forgotPassword(userToken: any) {
+  public forgotPassword(userToken: ForgotPasswordEmail) {
     this.mailerService
       .sendMail({
-        to: userToken.user,
+        to: userToken.user.email,
         from: this.getFromEmail(),
         subject: this.getSubject("Reset Password"),
         template: this.getEmailTemplatePath("forgotPassword"),
         context: {
-          user: userToken.user,
-          link: `${this.FRONT_APP_URL}/user/reset/${userToken.token}`,
+          user: userToken.user.email,
+          link: `${this.FRONT_APP_URL}/reset-password?token=${userToken.token}&name=${userToken.user.firstName}`,
         },
       })
       .then((data) => data)


### PR DESCRIPTION
This PR updates the reset password link sent to the user via email. It uses the newly added `FRONT_APP_URL` env variable as the base url for the front-end project.

It redirects the user to `/reset-password?token=:token&name=:name` so that the front-end team receives the token and user's first name as query parameters.

The PR also adds a new interface to get type safety when using the data received by the event emitter on the mail service.