### PR TITLE
refactor: update users endpoint methods

### DIFF
--- a/src/api/user/interfaces/users.controller.interface.ts
+++ b/src/api/user/interfaces/users.controller.interface.ts
@@ -1,25 +1,22 @@
-// remove eslint comment when you start to populate the interface
-
-import { CreateUserDto } from "../dtos/create-user.dto";
 import { ForgotPasswordDto, ResetPasswordDto } from "../dtos/password-reset.dto";
 import { UpdateUserDto } from "../dtos/update-user.dto";
 import { User } from "../entities/user.entity";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IUsersController {
-  getHello(user: User): Promise<string>;
+  // getHello(user: User): Promise<string>;
 
-  create(body: CreateUserDto): Promise<User>;
+  // create(body: CreateUserDto): Promise<User>;
 
   getMe(user: User): Promise<User>;
 
   findOne(userId: string): Promise<User>;
 
-  findAll(): Promise<User[]>;
+  // findAll(): Promise<User[]>;
 
   updateMe(user: User, body: UpdateUserDto): Promise<User>;
 
-  updateUser(userId: string, body: UpdateUserDto): Promise<User>;
+  // updateUser(userId: string, body: UpdateUserDto): Promise<User>;
 
   remove(userId: string): Promise<void>;
 

--- a/src/api/user/interfaces/users.controller.interface.ts
+++ b/src/api/user/interfaces/users.controller.interface.ts
@@ -5,24 +5,13 @@ import { User } from "../entities/user.entity";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IUsersController {
-  // getHello(user: User): Promise<string>;
-
-  // create(body: CreateUserDto): Promise<User>;
-
   getMe(user: User): Promise<User>;
 
   findOne(userId: string): Promise<User>;
 
-  // findAll(): Promise<User[]>;
-
   updateMe(user: User, body: UpdateUserDto): Promise<User>;
 
-  // updateUser(userId: string, body: UpdateUserDto): Promise<User>;
-
   deleteMe(user: User): Promise<IDeleteStatus>;
-
-  // addPermission(userId: string, permission: PermissinDto): Promise<void>;
-  // removePermission(userId: string, permission: PermissinDto): Promise<void>;
 
   forgotPassword(body: ForgotPasswordDto): Promise<void>;
 

--- a/src/api/user/interfaces/users.controller.interface.ts
+++ b/src/api/user/interfaces/users.controller.interface.ts
@@ -1,3 +1,4 @@
+import { IDeleteStatus } from "src/common/interfaces/DeleteStatus.interface";
 import { ForgotPasswordDto, ResetPasswordDto } from "../dtos/password-reset.dto";
 import { UpdateUserDto } from "../dtos/update-user.dto";
 import { User } from "../entities/user.entity";
@@ -18,7 +19,7 @@ export interface IUsersController {
 
   // updateUser(userId: string, body: UpdateUserDto): Promise<User>;
 
-  delete(userId: string): Promise<void>;
+  deleteMe(user: User): Promise<IDeleteStatus>;
 
   // addPermission(userId: string, permission: PermissinDto): Promise<void>;
   // removePermission(userId: string, permission: PermissinDto): Promise<void>;

--- a/src/api/user/interfaces/users.controller.interface.ts
+++ b/src/api/user/interfaces/users.controller.interface.ts
@@ -18,7 +18,7 @@ export interface IUsersController {
 
   // updateUser(userId: string, body: UpdateUserDto): Promise<User>;
 
-  remove(userId: string): Promise<void>;
+  delete(userId: string): Promise<void>;
 
   // addPermission(userId: string, permission: PermissinDto): Promise<void>;
   // removePermission(userId: string, permission: PermissinDto): Promise<void>;

--- a/src/api/user/interfaces/users.service.interface.ts
+++ b/src/api/user/interfaces/users.service.interface.ts
@@ -1,5 +1,6 @@
 // remove eslint comment when you start to populate the interface
 
+import { IDeleteStatus } from "src/common/interfaces/DeleteStatus.interface";
 import { CreateUserDto } from "../dtos/create-user.dto";
 import { ForgotPasswordDto, ResetPasswordDto } from "../dtos/password-reset.dto";
 import { UpdateUserDto } from "../dtos/update-user.dto";
@@ -15,7 +16,7 @@ export interface IUsersService {
 
   updateUser(userId: string, payload: UpdateUserDto): Promise<User>;
 
-  deleteUser(userId: string): Promise<void>;
+  deleteUser(userId: string): Promise<IDeleteStatus>;
 
   // addPermission(userId: string, permissionDto: PermissinDto): Promise<void>;
   // removePermission(userId: string, permissionDto: PermissinDto): Promise<void>;

--- a/src/api/user/interfaces/users.service.interface.ts
+++ b/src/api/user/interfaces/users.service.interface.ts
@@ -18,9 +18,6 @@ export interface IUsersService {
 
   deleteUser(userId: string): Promise<IDeleteStatus>;
 
-  // addPermission(userId: string, permissionDto: PermissinDto): Promise<void>;
-  // removePermission(userId: string, permissionDto: PermissinDto): Promise<void>;
-
   forgotPassword(forgotPassword: ForgotPasswordDto): Promise<void>;
 
   resetPassword(token: string, resetPasswordDto: ResetPasswordDto): Promise<void>;

--- a/src/api/user/interfaces/users.service.interface.ts
+++ b/src/api/user/interfaces/users.service.interface.ts
@@ -13,9 +13,9 @@ export interface IUsersService {
 
   findAll(): Promise<User[]>;
 
-  update(userId: string, payload: UpdateUserDto): Promise<User>;
+  updateUser(userId: string, payload: UpdateUserDto): Promise<User>;
 
-  remove(userId: string): Promise<void>;
+  deleteUser(userId: string): Promise<void>;
 
   // addPermission(userId: string, permissionDto: PermissinDto): Promise<void>;
   // removePermission(userId: string, permissionDto: PermissinDto): Promise<void>;

--- a/src/api/user/users.controller.ts
+++ b/src/api/user/users.controller.ts
@@ -44,19 +44,6 @@ import { UsersService } from "./users.service";
 export class UsersController implements IUsersController {
   constructor(private readonly usersService: UsersService) {}
 
-  // //example how permissions work
-  // @Permission(UserPermissions.CAN_ACCESS_HELLO_METHOD)
-  // @Get("hello")
-  // async getHello() {
-  //   return "Hello from Hello Method";
-  // }
-
-  // @Roles(UserRoles.SUPER_ADMIN)
-  // @Post()
-  // async create(@Body() body: CreateUserDto): Promise<User> {
-  //   return await this.usersService.create(body);
-  // }
-
   @ApiOperation({
     summary: "Get the current user",
     description: "Retrieves the current user based on the provided token",
@@ -74,8 +61,6 @@ export class UsersController implements IUsersController {
     return await this.usersService.findOne(user.uuid);
   }
 
-  // example how roles work
-  // @Roles(UserRoles.SUPER_ADMIN)
   @ApiOperation({
     summary: "Get a user by ID",
     description: "Retrieves a user based on the provided UUID",
@@ -92,13 +77,6 @@ export class UsersController implements IUsersController {
   async findOne(@Param("userId") userId: string): Promise<User> {
     return await this.usersService.findOne(userId);
   }
-
-  // @Roles(UserRoles.SUPER_ADMIN)
-  // @Get()
-  // @UseInterceptors(PaginationInterceptor)
-  // async findAll(): Promise<User[]> {
-  //   return await this.usersService.findAll();
-  // }
 
   @ApiOperation({
     summary: "Update the current user",
@@ -117,16 +95,6 @@ export class UsersController implements IUsersController {
     return await this.usersService.updateUser(user.uuid, body);
   }
 
-  // @Roles(UserRoles.SUPER_ADMIN)
-  // @Patch(":userId")
-  // async updateUser(
-  //   @Param("userId") userId: string,
-  //   @Body() body: UpdateUserDto,
-  // ): Promise<User> {
-  //   return await this.usersService.update(userId, body);
-  // }
-
-  // @Roles(UserRoles.SUPER_ADMIN)
   @ApiOperation({
     summary: "Delete the current user",
     description: "Deletes the current user based on the provided token",
@@ -143,24 +111,6 @@ export class UsersController implements IUsersController {
   async deleteMe(@GetCurrentUser() user: User): Promise<IDeleteStatus> {
     return await this.usersService.deleteUser(user.uuid);
   }
-
-  // @Roles(UserRoles.SUPER_ADMIN)
-  // @Post("add-permission/:userId")
-  // async addPermission(
-  //   @Param("userId") userId: string,
-  //   @Body() permission: PermissinDto,
-  // ): Promise<void> {
-  //   return this.usersService.addPermission(userId, permission);
-  // }
-
-  // @Roles(UserRoles.SUPER_ADMIN)
-  // @Post("remove-permission/:userId")
-  // async removePermission(
-  //   @Param("userId") userId: string,
-  //   @Body() permission: PermissinDto,
-  // ): Promise<void> {
-  //   return this.usersService.removePermission(userId, permission);
-  // }
 
   @ApiOperation({
     summary: "Send a password reset email",

--- a/src/api/user/users.controller.ts
+++ b/src/api/user/users.controller.ts
@@ -12,8 +12,18 @@ import {
   UsePipes,
   ValidationPipe,
 } from "@nestjs/common";
-import { ApiBearerAuth, ApiTags } from "@nestjs/swagger";
+import {
+  ApiBearerAuth,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnprocessableEntityResponse,
+} from "@nestjs/swagger";
 import { IDeleteStatus } from "src/common/interfaces/DeleteStatus.interface";
+import { DeletedResponse } from "src/common/interfaces/responses/deleted.response";
+import { NotFoundResponse } from "src/common/interfaces/responses/not-found.response";
+import { UnprocessableEntityResponse } from "src/common/interfaces/responses/unprocessable-entity.response";
 import { GetCurrentUser } from "../../common/decorators/get-current-user.decorator";
 import { Public } from "../../common/decorators/public.decorator";
 import { PermissionsGuard } from "../../common/guards/permissions.guard";
@@ -47,6 +57,18 @@ export class UsersController implements IUsersController {
   //   return await this.usersService.create(body);
   // }
 
+  @ApiOperation({
+    summary: "Get the current user",
+    description: "Retrieves the current user based on the provided token",
+  })
+  @ApiOkResponse({
+    description: "A 200 response if the user is found successfully",
+    type: User,
+  })
+  @ApiNotFoundResponse({
+    description: "A 404 error if the user doesn't exist",
+    type: NotFoundResponse,
+  })
   @Get("me")
   async getMe(@GetCurrentUser() user: User): Promise<User> {
     return await this.usersService.findOne(user.uuid);
@@ -54,6 +76,18 @@ export class UsersController implements IUsersController {
 
   // example how roles work
   // @Roles(UserRoles.SUPER_ADMIN)
+  @ApiOperation({
+    summary: "Get a user by ID",
+    description: "Retrieves a user based on the provided UUID",
+  })
+  @ApiOkResponse({
+    description: "A 200 response if the user is found successfully",
+    type: User,
+  })
+  @ApiNotFoundResponse({
+    description: "A 404 error if the user doesn't exist",
+    type: NotFoundResponse,
+  })
   @Get(":userId")
   async findOne(@Param("userId") userId: string): Promise<User> {
     return await this.usersService.findOne(userId);
@@ -66,6 +100,18 @@ export class UsersController implements IUsersController {
   //   return await this.usersService.findAll();
   // }
 
+  @ApiOperation({
+    summary: "Update the current user",
+    description: "Updates the current user based on the provided token",
+  })
+  @ApiOkResponse({
+    description: "A 200 response if the user is updated successfully",
+    type: User,
+  })
+  @ApiNotFoundResponse({
+    description: "A 404 error if the user doesn't exist",
+    type: NotFoundResponse,
+  })
   @Patch("me")
   async updateMe(@GetCurrentUser() user: User, @Body() body: UpdateUserDto) {
     return await this.usersService.updateUser(user.uuid, body);
@@ -81,6 +127,18 @@ export class UsersController implements IUsersController {
   // }
 
   // @Roles(UserRoles.SUPER_ADMIN)
+  @ApiOperation({
+    summary: "Delete the current user",
+    description: "Deletes the current user based on the provided token",
+  })
+  @ApiOkResponse({
+    description: "A 200 response if the user is deleted successfully",
+    type: DeletedResponse,
+  })
+  @ApiNotFoundResponse({
+    description: "A 404 error if the user doesn't exist",
+    type: NotFoundResponse,
+  })
   @Delete("/me")
   async deleteMe(@GetCurrentUser() user: User): Promise<IDeleteStatus> {
     return await this.usersService.deleteUser(user.uuid);
@@ -104,12 +162,34 @@ export class UsersController implements IUsersController {
   //   return this.usersService.removePermission(userId, permission);
   // }
 
+  @ApiOperation({
+    summary: "Send a password reset email",
+    description: "Sends an email to the user with a token to reset their password",
+  })
+  @ApiOkResponse({
+    description: "A 200 response if the email is sent successfully",
+  })
+  @ApiNotFoundResponse({
+    description: "A 404 error if the user doesn't exist",
+    type: NotFoundResponse,
+  })
   @Public()
   @Post("forgot")
   async forgotPassword(@Body() body: ForgotPasswordDto): Promise<void> {
     return await this.usersService.forgotPassword(body);
   }
 
+  @ApiOperation({
+    summary: "Reset the user's password",
+    description: "Resets the user's password using the provided token",
+  })
+  @ApiOkResponse({
+    description: "A 200 response if the password is reset successfully",
+  })
+  @ApiUnprocessableEntityResponse({
+    description: "A 422 error if the token is invalid or expired",
+    type: UnprocessableEntityResponse,
+  })
   @Public()
   @Post("reset/:token")
   async resetPassword(

--- a/src/api/user/users.controller.ts
+++ b/src/api/user/users.controller.ts
@@ -14,24 +14,18 @@ import {
 } from "@nestjs/common";
 import { ApiBearerAuth, ApiTags } from "@nestjs/swagger";
 import { GetCurrentUser } from "../../common/decorators/get-current-user.decorator";
-import { Permission } from "../../common/decorators/permissions.decorator";
 import { Public } from "../../common/decorators/public.decorator";
-import { Roles } from "../../common/decorators/roles.decorator";
 import { PermissionsGuard } from "../../common/guards/permissions.guard";
 import { RolesGuard } from "../../common/guards/roles.guard";
-import { PaginationInterceptor } from "../../common/interceptors/pagination.interceptor";
-import { CreateUserDto } from "./dtos/create-user.dto";
 import { ForgotPasswordDto, ResetPasswordDto } from "./dtos/password-reset.dto";
 import { UpdateUserDto } from "./dtos/update-user.dto";
 import { User } from "./entities/user.entity";
-import { UserPermissions } from "./enums/permissions.enum";
-import { UserRoles } from "./enums/roles.enum";
 import { IUsersController } from "./interfaces/users.controller.interface";
 import { UsersService } from "./users.service";
 
-@Controller("user")
+@Controller("users")
 @ApiBearerAuth()
-@ApiTags("User")
+@ApiTags("Users")
 @UsePipes(new ValidationPipe())
 @UseInterceptors(ClassSerializerInterceptor)
 @UseGuards(PermissionsGuard)
@@ -39,18 +33,18 @@ import { UsersService } from "./users.service";
 export class UsersController implements IUsersController {
   constructor(private readonly usersService: UsersService) {}
 
-  //example how permissions work
-  @Permission(UserPermissions.CAN_ACCESS_HELLO_METHOD)
-  @Get("hello")
-  async getHello() {
-    return "Hello from Hello Method";
-  }
+  // //example how permissions work
+  // @Permission(UserPermissions.CAN_ACCESS_HELLO_METHOD)
+  // @Get("hello")
+  // async getHello() {
+  //   return "Hello from Hello Method";
+  // }
 
-  @Roles(UserRoles.SUPER_ADMIN)
-  @Post()
-  async create(@Body() body: CreateUserDto): Promise<User> {
-    return await this.usersService.create(body);
-  }
+  // @Roles(UserRoles.SUPER_ADMIN)
+  // @Post()
+  // async create(@Body() body: CreateUserDto): Promise<User> {
+  //   return await this.usersService.create(body);
+  // }
 
   @Get("me")
   async getMe(@GetCurrentUser() user: User): Promise<User> {
@@ -58,34 +52,34 @@ export class UsersController implements IUsersController {
   }
 
   // example how roles work
-  @Roles(UserRoles.SUPER_ADMIN)
+  // @Roles(UserRoles.SUPER_ADMIN)
   @Get(":userId")
   async findOne(@Param("userId") userId: string): Promise<User> {
     return await this.usersService.findOne(userId);
   }
 
-  @Roles(UserRoles.SUPER_ADMIN)
-  @Get()
-  @UseInterceptors(PaginationInterceptor)
-  async findAll(): Promise<User[]> {
-    return await this.usersService.findAll();
-  }
+  // @Roles(UserRoles.SUPER_ADMIN)
+  // @Get()
+  // @UseInterceptors(PaginationInterceptor)
+  // async findAll(): Promise<User[]> {
+  //   return await this.usersService.findAll();
+  // }
 
   @Patch("me")
   async updateMe(@GetCurrentUser() user: User, @Body() body: UpdateUserDto) {
     return await this.usersService.update(user.uuid, body);
   }
 
-  @Roles(UserRoles.SUPER_ADMIN)
-  @Patch(":userId")
-  async updateUser(
-    @Param("userId") userId: string,
-    @Body() body: UpdateUserDto,
-  ): Promise<User> {
-    return await this.usersService.update(userId, body);
-  }
+  // @Roles(UserRoles.SUPER_ADMIN)
+  // @Patch(":userId")
+  // async updateUser(
+  //   @Param("userId") userId: string,
+  //   @Body() body: UpdateUserDto,
+  // ): Promise<User> {
+  //   return await this.usersService.update(userId, body);
+  // }
 
-  @Roles(UserRoles.SUPER_ADMIN)
+  // @Roles(UserRoles.SUPER_ADMIN)
   @Delete(":userId")
   async remove(@Param("userId") userId: string): Promise<void> {
     return await this.usersService.remove(userId);

--- a/src/api/user/users.controller.ts
+++ b/src/api/user/users.controller.ts
@@ -13,6 +13,7 @@ import {
   ValidationPipe,
 } from "@nestjs/common";
 import { ApiBearerAuth, ApiTags } from "@nestjs/swagger";
+import { IDeleteStatus } from "src/common/interfaces/DeleteStatus.interface";
 import { GetCurrentUser } from "../../common/decorators/get-current-user.decorator";
 import { Public } from "../../common/decorators/public.decorator";
 import { PermissionsGuard } from "../../common/guards/permissions.guard";
@@ -80,9 +81,9 @@ export class UsersController implements IUsersController {
   // }
 
   // @Roles(UserRoles.SUPER_ADMIN)
-  @Delete(":userId")
-  async delete(@Param("userId") userId: string): Promise<void> {
-    return await this.usersService.deleteUser(userId);
+  @Delete("/me")
+  async deleteMe(@GetCurrentUser() user: User): Promise<IDeleteStatus> {
+    return await this.usersService.deleteUser(user.uuid);
   }
 
   // @Roles(UserRoles.SUPER_ADMIN)

--- a/src/api/user/users.controller.ts
+++ b/src/api/user/users.controller.ts
@@ -67,7 +67,7 @@ export class UsersController implements IUsersController {
 
   @Patch("me")
   async updateMe(@GetCurrentUser() user: User, @Body() body: UpdateUserDto) {
-    return await this.usersService.update(user.uuid, body);
+    return await this.usersService.updateUser(user.uuid, body);
   }
 
   // @Roles(UserRoles.SUPER_ADMIN)
@@ -81,8 +81,8 @@ export class UsersController implements IUsersController {
 
   // @Roles(UserRoles.SUPER_ADMIN)
   @Delete(":userId")
-  async remove(@Param("userId") userId: string): Promise<void> {
-    return await this.usersService.remove(userId);
+  async delete(@Param("userId") userId: string): Promise<void> {
+    return await this.usersService.deleteUser(userId);
   }
 
   // @Roles(UserRoles.SUPER_ADMIN)

--- a/src/api/user/users.service.ts
+++ b/src/api/user/users.service.ts
@@ -86,28 +86,6 @@ export class UsersService implements IUsersService {
     };
   }
 
-  // async addPermission(userId: string, permissionDto: PermissinDto): Promise<void> {
-  //   const user = await this.findOne(userId);
-
-  //   const permissionExist = checkPermissionsUtil(user.permissions, permissionDto.permission);
-  //   if (permissionExist) {
-  //     throw new UnprocessableEntityException("Permission was already added!");
-  //   }
-  //   user.permissions += permissionDto.permission;
-  //   await this.userRepository.save(user);
-  // }
-
-  // async removePermission(userId: string, permissionDto: PermissinDto): Promise<void> {
-  //   const user = await this.findOne(userId);
-
-  //   const permissionExist = checkPermissionsUtil(user.permissions, permissionDto.permission);
-  //   if (!permissionExist) {
-  //     throw new UnprocessableEntityException("Permission was already removed");
-  //   }
-  //   user.permissions -= permissionDto.permission;
-  //   await this.userRepository.save(user);
-  // }
-
   /**
    * Sends an email to the user with a token to reset their password
    *

--- a/src/api/user/users.service.ts
+++ b/src/api/user/users.service.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 import EventEmitter from "node:events";
 import { Injectable } from "@nestjs/common";
-import { UnprocessableEntityException } from "@nestjs/common/exceptions";
+import { NotFoundException, UnprocessableEntityException } from "@nestjs/common/exceptions";
 import { InjectRepository } from "@nestjs/typeorm";
 import { InjectEventEmitter } from "nest-emitter";
 import { IDeleteStatus } from "src/common/interfaces/DeleteStatus.interface";
@@ -38,7 +38,7 @@ export class UsersService implements IUsersService {
   async findOne(userId: string): Promise<User> {
     const user = await this.userRepository.findOneBy({ uuid: userId });
     if (!user) {
-      throw new UnprocessableEntityException("This user does not exist!");
+      throw new NotFoundException("This user does not exist!");
     }
     return user;
   }
@@ -121,7 +121,7 @@ export class UsersService implements IUsersService {
     });
 
     if (!user) {
-      throw new UnprocessableEntityException("This user does not exist!");
+      throw new NotFoundException("This user does not exist!");
     }
 
     const count = await this.passwordRepository.count({

--- a/src/api/user/users.service.ts
+++ b/src/api/user/users.service.ts
@@ -59,7 +59,7 @@ export class UsersService implements IUsersService {
    * @returns Promise that resolves to the updated user
    * @throws {NotFoundException} - If no user is found with the given UUID
    */
-  async update(userId: string, payload: UpdateUserDto): Promise<User> {
+  async updateUser(userId: string, payload: UpdateUserDto): Promise<User> {
     const user = await this.findOne(userId);
     await this.userRepository.update(user.id, payload);
 
@@ -72,7 +72,7 @@ export class UsersService implements IUsersService {
    * @param userId - The unique UUID of the user
    * @throws {NotFoundException} - If no user with the given UUID is found
    */
-  async remove(userId: string): Promise<void> {
+  async deleteUser(userId: string): Promise<void> {
     const user = await this.findOne(userId);
     await this.userRepository.softRemove(user);
   }

--- a/src/api/user/users.service.ts
+++ b/src/api/user/users.service.ts
@@ -74,7 +74,7 @@ export class UsersService implements IUsersService {
    */
   async remove(userId: string): Promise<void> {
     const user = await this.findOne(userId);
-    await this.userRepository.remove(user);
+    await this.userRepository.softRemove(user);
   }
 
   // async addPermission(userId: string, permissionDto: PermissinDto): Promise<void> {

--- a/src/api/user/users.service.ts
+++ b/src/api/user/users.service.ts
@@ -4,6 +4,7 @@ import { Injectable } from "@nestjs/common";
 import { UnprocessableEntityException } from "@nestjs/common/exceptions";
 import { InjectRepository } from "@nestjs/typeorm";
 import { InjectEventEmitter } from "nest-emitter";
+import { IDeleteStatus } from "src/common/interfaces/DeleteStatus.interface";
 import { Repository } from "typeorm";
 import { hashDataBrypt } from "../../services/providers";
 import { CreateUserDto } from "./dtos/create-user.dto";
@@ -72,9 +73,17 @@ export class UsersService implements IUsersService {
    * @param userId - The unique UUID of the user
    * @throws {NotFoundException} - If no user with the given UUID is found
    */
-  async deleteUser(userId: string): Promise<void> {
+  async deleteUser(userId: string): Promise<IDeleteStatus> {
     const user = await this.findOne(userId);
     await this.userRepository.softRemove(user);
+
+    return {
+      success: true,
+      resourceType: "user",
+      resourceId: userId,
+      message: "User deleted successfully",
+      timestamp: new Date(),
+    };
   }
 
   // async addPermission(userId: string, permissionDto: PermissinDto): Promise<void> {

--- a/src/common/interfaces/responses/unprocessable-entity.response.ts
+++ b/src/common/interfaces/responses/unprocessable-entity.response.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IApiResponse } from "../ApiResponse.interface";
+
+export class UnprocessableEntityResponse implements IApiResponse {
+  @ApiProperty({
+    type: Number,
+    description: "HTTP status code",
+    example: 422,
+  })
+  statusCode: number;
+
+  @ApiProperty({
+    type: String,
+    description: "HTTP method error",
+    example: "Unprocessable Entity",
+  })
+  error: string;
+
+  @ApiProperty({
+    type: String,
+    description: "Error description",
+    example: "The request couldn't be processed due to semantic errors.",
+  })
+  message: string;
+}


### PR DESCRIPTION
This PR does the following

- Removes unnecessary routes from the users endpoint
- Makes user deletion return a delete status object
- Makes the delete endpoint be for the current logged in user only
- Changes user deletion to be soft delete
- Changes base endpoint name from `user` -> `users`
- Adds documentation for users endpoint