### PR TITLE
docs: add documentation for auth endpoint

### DIFF
--- a/src/api/auth/auth.controller.ts
+++ b/src/api/auth/auth.controller.ts
@@ -10,7 +10,23 @@ import {
   UsePipes,
   ValidationPipe,
 } from "@nestjs/common";
-import { ApiBearerAuth, ApiTags } from "@nestjs/swagger";
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from "@nestjs/swagger";
+import { BadRequestResponse } from "src/common/interfaces/responses/bad-request.response";
+import { ForbiddenResponse } from "src/common/interfaces/responses/forbidden.response";
+import { InternalErrorResponse } from "src/common/interfaces/responses/internal-error.response";
+import { LoginUserResponse } from "src/common/interfaces/responses/login-user.respons";
+import { UnauthorizedResponse } from "src/common/interfaces/responses/unauthorized.response";
+import { UserTokensResponse } from "src/common/interfaces/responses/user-tokens.response";
 import { GetCurrentUserId } from "../../common/decorators/get-current-user-id.decorator";
 import { Public } from "../../common/decorators/public.decorator";
 import { AccessTokenGuard } from "../../common/guards/access-token.guard";
@@ -29,6 +45,18 @@ import { Tokens } from "./types/tokens.types";
 export class AuthController implements IAuthController {
   constructor(private readonly authService: AuthService) {}
 
+  @ApiOperation({
+    summary: "Register a new user",
+    description: "Registers a new user and returns access and refresh tokens.",
+  })
+  @ApiCreatedResponse({
+    description: "A 201 response if the user is registered successfully",
+    type: UserTokensResponse,
+  })
+  @ApiInternalServerErrorResponse({
+    description: "A 500 error if the user registration fails",
+    type: InternalErrorResponse,
+  })
   @Public()
   @Post("register")
   @HttpCode(HttpStatus.CREATED)
@@ -36,6 +64,18 @@ export class AuthController implements IAuthController {
     return await this.authService.signup(registerDto);
   }
 
+  @ApiOperation({
+    summary: "Login as a user",
+    description: "Logs in a user and returns access and refresh tokens.",
+  })
+  @ApiOkResponse({
+    description: "A 200 response if the user is logged in successfully",
+    type: LoginUserResponse,
+  })
+  @ApiBadRequestResponse({
+    description: "A 400 error if the user credentials are invalid",
+    type: BadRequestResponse,
+  })
   @Public()
   @Post("login")
   @HttpCode(HttpStatus.OK)
@@ -43,6 +83,10 @@ export class AuthController implements IAuthController {
     return this.authService.login(loginDto);
   }
 
+  @ApiOperation({
+    summary: "Log out as a user",
+    description: "Logs out a user by invalidating their refresh token.",
+  })
   @UseGuards(AccessTokenGuard)
   @Post("logout")
   @HttpCode(HttpStatus.OK)
@@ -50,6 +94,22 @@ export class AuthController implements IAuthController {
     return this.authService.logout(userId);
   }
 
+  @ApiOperation({
+    summary: "Refresh user tokens",
+    description: "Refreshes the access token using the refresh token.",
+  })
+  @ApiOkResponse({
+    description: "A 200 response if the refresh token is valid",
+    type: UserTokensResponse,
+  })
+  @ApiForbiddenResponse({
+    description: "A 403 error if the user doesn't exist or is not logged in",
+    type: ForbiddenResponse,
+  })
+  @ApiUnauthorizedResponse({
+    description: "A 401 error if the refresh token is invalid",
+    type: UnauthorizedResponse,
+  })
   @Public()
   @Post("refresh-token")
   @HttpCode(HttpStatus.OK)

--- a/src/api/auth/dtos/refresh-token.dto.ts
+++ b/src/api/auth/dtos/refresh-token.dto.ts
@@ -1,6 +1,13 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { IsNotEmpty, IsString } from "class-validator";
 
 export class RefreshTokenDto {
+  @ApiProperty({
+    type: String,
+    description: "Refresh token for the user",
+    example:
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+  })
   @IsNotEmpty()
   @IsString()
   refreshToken: string;

--- a/src/common/interfaces/responses/forbidden.response.ts
+++ b/src/common/interfaces/responses/forbidden.response.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class ForbiddenResponse {
+  @ApiProperty({
+    type: Number,
+    description: "HTTP status code",
+    example: 403,
+  })
+  statusCode: number;
+
+  @ApiProperty({
+    type: String,
+    description: "HTTP method error",
+    example: "Forbidden",
+  })
+  error: string;
+
+  @ApiProperty({
+    type: String,
+    description: "Error description",
+    example: "Forbidden resource",
+  })
+  message: string;
+}

--- a/src/common/interfaces/responses/login-user.respons.ts
+++ b/src/common/interfaces/responses/login-user.respons.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { User } from "src/api/user/entities/user.entity";
+
+export class LoginUserResponse {
+  @ApiProperty({
+    type: String,
+    description: "Access token for the user",
+    example:
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+  })
+  accessToken: string;
+
+  @ApiProperty({
+    type: String,
+    description: "Refresh token for the user",
+    example:
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+  })
+  refreshToken: string;
+
+  @ApiProperty({
+    type: User,
+    description: "User object",
+  })
+  user: User;
+}

--- a/src/common/interfaces/responses/user-tokens.response.ts
+++ b/src/common/interfaces/responses/user-tokens.response.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class UserTokensResponse {
+  @ApiProperty({
+    type: String,
+    description: "Access token for the user",
+    example:
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+  })
+  accessToken: string;
+
+  @ApiProperty({
+    type: String,
+    description: "Refresh token for the user",
+    example:
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+  })
+  refreshToken: string;
+}


### PR DESCRIPTION
This PR adds documentation for the `/auth` endpoint, including individual route documentation, as well as missing docs for the `refreshTokenDTO`.

It also adds 3 new API response classes for:

- `403 Forbidden` responses
- Responses with access & refresh tokens
- Responses with the user object & user tokens