### PR TITLE
feature: restrict findRooms to current users rooms only

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
 		"@types/jest": "29.2.4",
 		"@types/node": "18.11.18",
 		"@types/supertest": "^2.0.11",
+		"@types/uuid": "^10.0.0",
 		"@typescript-eslint/eslint-plugin": "^5.0.0",
 		"@typescript-eslint/parser": "^5.0.0",
 		"eslint": "^8.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       '@types/supertest':
         specifier: ^2.0.11
         version: 2.0.16
+      '@types/uuid':
+        specifier: ^10.0.0
+        version: 10.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.0.0
         version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
@@ -1043,6 +1046,9 @@ packages:
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@types/validator@13.15.0':
     resolution: {integrity: sha512-nh7nrWhLr6CBq9ldtw0wx+z9wKnnv/uTVLA9g/3/TcOYxbpOSZE+MhKPmWqU+K0NvThjhv12uD8MuqijB0WzEA==}
@@ -5705,6 +5711,8 @@ snapshots:
       '@types/superagent': 8.1.9
 
   '@types/triple-beam@1.3.5': {}
+
+  '@types/uuid@10.0.0': {}
 
   '@types/validator@13.15.0': {}
 

--- a/src/api/rooms/entities/room.entity.ts
+++ b/src/api/rooms/entities/room.entity.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { Note } from "src/api/notes/entities/note.entity";
 import { AuditEntity } from "src/common/db/customBaseEntites/AuditEntity";
 import { slug } from "src/utils/slug";
@@ -7,12 +8,27 @@ import { RoomUsers } from "./room-users.entity";
 @Entity("rooms")
 export class Room extends AuditEntity {
   @Column({ type: "varchar", length: 100, nullable: false })
+  @ApiProperty({
+    type: String,
+    description: "Room's title",
+    example: "Intership Project",
+  })
   title: string;
 
   @Column({ type: "varchar", length: 255, unique: true })
+  @ApiProperty({
+    type: String,
+    description: "Room's slug",
+    example: "intership-project",
+  })
   slug: string;
 
   @Column({ name: "is_active", type: "boolean", nullable: false, default: true })
+  @ApiProperty({
+    type: Boolean,
+    description: "Is room active",
+    example: "true",
+  })
   isActive: boolean;
 
   @OneToMany(

--- a/src/api/rooms/interfaces/rooms.controller.interface.ts
+++ b/src/api/rooms/interfaces/rooms.controller.interface.ts
@@ -4,11 +4,12 @@ import { CreateRoomDto } from "../dtos/create-room.dto";
 import { UpdateRoomDto } from "../dtos/update-room.dto";
 import { RoomUsers } from "../entities/room-users.entity";
 import { Room } from "../entities/room.entity";
+import { Roles } from "../enums/roles.enum";
 
 export interface IRoomsController {
   findById(roomId: string): Promise<Room>;
 
-  findRooms(): Promise<Room[]>;
+  findRooms(user: User): Promise<{ room: Room; role: Roles }[]>;
 
   create(body: CreateRoomDto, user: User): Promise<Room>;
 

--- a/src/api/rooms/interfaces/rooms.service.interface.ts
+++ b/src/api/rooms/interfaces/rooms.service.interface.ts
@@ -3,11 +3,12 @@ import { CreateRoomDto } from "../dtos/create-room.dto";
 import { UpdateRoomDto } from "../dtos/update-room.dto";
 import { RoomUsers } from "../entities/room-users.entity";
 import { Room } from "../entities/room.entity";
+import { Roles } from "../enums/roles.enum";
 
 export interface IRoomsService {
   findById(roomId: string): Promise<Room>;
 
-  findRooms(): Promise<Room[]>;
+  findRooms(userId: string): Promise<{ room: Room; role: Roles }[]>;
 
   createRoom(payload: CreateRoomDto, userId: string): Promise<Room>;
 

--- a/src/api/rooms/rooms.controller.ts
+++ b/src/api/rooms/rooms.controller.ts
@@ -77,7 +77,8 @@ export class RoomsController implements IRoomsController {
   })
   @Get()
   async findRooms(@GetCurrentUser() user: User): Promise<{ room: Room; role: Roles }[]> {
-    return this.roomsService.findRooms(user.uuid);
+    const { uuid } = user;
+    return this.roomsService.findRooms(uuid);
   }
 
   @ApiOperation({
@@ -93,7 +94,8 @@ export class RoomsController implements IRoomsController {
   })
   @Post()
   async create(@Body() body: CreateRoomDto, @GetCurrentUser() user: User): Promise<Room> {
-    return this.roomsService.createRoom(body, user.uuid);
+    const { uuid } = user;
+    return this.roomsService.createRoom(body, uuid);
   }
 
   @ApiOperation({
@@ -165,7 +167,8 @@ export class RoomsController implements IRoomsController {
     @GetCurrentUser() user: User,
     @Param("roomId", new ParseUUIDPipe()) roomId: string,
   ): Promise<RoomUsers> {
-    return this.roomsService.joinRoom(user.uuid, roomId);
+    const { uuid } = user;
+    return this.roomsService.joinRoom(uuid, roomId);
   }
 
   @Post("leave/:roomId")
@@ -173,7 +176,8 @@ export class RoomsController implements IRoomsController {
     @GetCurrentUser() user: User,
     @Param("roomId", new ParseUUIDPipe()) roomId: string,
   ): Promise<boolean> {
-    return this.roomsService.leaveRoom(user.uuid, roomId);
+    const { uuid } = user;
+    return this.roomsService.leaveRoom(uuid, roomId);
   }
 
   @Post("remove/:roomId")

--- a/src/api/rooms/rooms.controller.ts
+++ b/src/api/rooms/rooms.controller.ts
@@ -144,6 +144,21 @@ export class RoomsController implements IRoomsController {
     return this.roomsService.deleteRoom(roomId);
   }
 
+  @ApiOperation({
+    summary: "Join a room",
+    description: "Join a room as a participant",
+  })
+  @ApiCreatedResponse({
+    description: "A 201 response if the user joined room successfully",
+  })
+  @ApiNotFoundResponse({
+    description: "A 404 error if the room doesn't exist",
+    type: NotFoundResponse,
+  })
+  @ApiUnauthorizedResponse({
+    description: "A 401 error if no bearer token is provided",
+    type: UnauthorizedResponse,
+  })
   @Post("join/:roomId")
   async join(
     @GetCurrentUser() user: User,

--- a/src/api/rooms/rooms.controller.ts
+++ b/src/api/rooms/rooms.controller.ts
@@ -24,6 +24,7 @@ import { BadRequestResponse } from "src/common/interfaces/responses/bad-request.
 import { DeletedResponse } from "src/common/interfaces/responses/deleted.response";
 import { GetRoomsResponse } from "src/common/interfaces/responses/get-rooms.response";
 import { NotFoundResponse } from "src/common/interfaces/responses/not-found.response";
+import { RoomRelationsResponse } from "src/common/interfaces/responses/room-relations.response";
 import { UnauthorizedResponse } from "src/common/interfaces/responses/unauthorized.response";
 import { User } from "../user/entities/user.entity";
 import { CreateRoomDto } from "./dtos/create-room.dto";
@@ -42,11 +43,11 @@ export class RoomsController implements IRoomsController {
 
   @ApiOperation({
     summary: "Get one room by id",
-    description: "Retrieves the room with the specified id",
+    description: "Retrieves the room with the specified id and it's relations",
   })
   @ApiOkResponse({
     description: "A 200 response if room is found",
-    type: Room,
+    type: RoomRelationsResponse,
   })
   @ApiUnauthorizedResponse({
     description: "A 401 error if no bearer token is provided",
@@ -58,12 +59,12 @@ export class RoomsController implements IRoomsController {
   })
   @Get(":roomId")
   async findById(@Param("roomId", new ParseUUIDPipe()) roomId: string): Promise<Room> {
-    return this.roomsService.findById(roomId);
+    return this.roomsService.findWithRelations(roomId);
   }
 
   @ApiOperation({
     summary: "Get all rooms",
-    description: "Retrieves all rooms",
+    description: "Retrieves all current user's rooms",
   })
   @ApiOkResponse({
     description: "A 200 response if rooms are found successfully",

--- a/src/api/rooms/rooms.controller.ts
+++ b/src/api/rooms/rooms.controller.ts
@@ -22,6 +22,7 @@ import { GetCurrentUser } from "src/common/decorators/get-current-user.decorator
 import { IDeleteStatus } from "src/common/interfaces/DeleteStatus.interface";
 import { BadRequestResponse } from "src/common/interfaces/responses/bad-request.response";
 import { DeletedResponse } from "src/common/interfaces/responses/deleted.response";
+import { GetRoomsResponse } from "src/common/interfaces/responses/get-rooms.response";
 import { NotFoundResponse } from "src/common/interfaces/responses/not-found.response";
 import { UnauthorizedResponse } from "src/common/interfaces/responses/unauthorized.response";
 import { User } from "../user/entities/user.entity";
@@ -29,6 +30,7 @@ import { CreateRoomDto } from "./dtos/create-room.dto";
 import { UpdateRoomDto } from "./dtos/update-room.dto";
 import { RoomUsers } from "./entities/room-users.entity";
 import { Room } from "./entities/room.entity";
+import { Roles } from "./enums/roles.enum";
 import { IRoomsController } from "./interfaces/rooms.controller.interface";
 import { RoomsService } from "./rooms.service";
 
@@ -65,7 +67,7 @@ export class RoomsController implements IRoomsController {
   })
   @ApiOkResponse({
     description: "A 200 response if rooms are found successfully",
-    type: Room,
+    type: GetRoomsResponse,
     isArray: true,
   })
   @ApiUnauthorizedResponse({
@@ -73,8 +75,8 @@ export class RoomsController implements IRoomsController {
     type: UnauthorizedResponse,
   })
   @Get()
-  async findRooms(): Promise<Room[]> {
-    return this.roomsService.findRooms();
+  async findRooms(@GetCurrentUser() user: User): Promise<{ room: Room; role: Roles }[]> {
+    return this.roomsService.findRooms(user.uuid);
   }
 
   @ApiOperation({
@@ -116,7 +118,7 @@ export class RoomsController implements IRoomsController {
   @Patch(":roomId")
   async update(
     @Param("roomId", new ParseUUIDPipe()) roomId: string,
-    body: UpdateRoomDto,
+    @Body() body: UpdateRoomDto,
   ): Promise<Room> {
     return this.roomsService.updateRoom(roomId, body);
   }

--- a/src/api/rooms/rooms.service.ts
+++ b/src/api/rooms/rooms.service.ts
@@ -100,7 +100,6 @@ export class RoomsService implements IRoomsService {
     });
 
     if (error) {
-      console.log(error);
       throw new InternalServerErrorException("There was an error processing your request");
     }
     if (!room) {

--- a/src/api/rooms/rooms.service.ts
+++ b/src/api/rooms/rooms.service.ts
@@ -32,7 +32,7 @@ export class RoomsService implements IRoomsService {
    */
   async findById(roomId: string): Promise<Room> {
     const [room, error] = await tryCatch(
-      this.roomsRepository.findOne({ where: { uuid: roomId } }),
+      this.roomsRepository.findOne({ where: { uuid: roomId }, relations: ["notes"] }),
     );
 
     if (error)
@@ -50,13 +50,18 @@ export class RoomsService implements IRoomsService {
    * @returns Promise that resolves to an array of rooms
    * @throws {InternalServerErrorException} - If there was an error processing the request
    */
-  async findRooms(): Promise<Room[]> {
-    const [rooms, error] = await tryCatch(this.roomsRepository.find());
+  async findRooms(userId: string): Promise<{ room: Room; role: Roles }[]> {
+    const [roomUsers, error] = await tryCatch(
+      this.roomUsersRepository.find({
+        where: { user: { uuid: userId } },
+        relations: ["room"],
+      }),
+    );
 
     if (error)
       throw new InternalServerErrorException("There was an error processing your request");
 
-    return rooms;
+    return roomUsers.map((ru) => ({ room: ru.room, role: ru.role }));
   }
 
   /**

--- a/src/common/db/seeds/rooms/add-to-room.seed.ts
+++ b/src/common/db/seeds/rooms/add-to-room.seed.ts
@@ -15,10 +15,12 @@ export class AddToRoomSeeder implements Seeder {
     const roomUsersRepository = AppDataSource.getRepository(RoomUsers);
 
     const emails = [
-      "argjend@kutia.net",
-      "blend@kutia.net",
-      "lendrit@kutia.net",
-      "leutrim@kutia.net",
+      "desara@kutia.net",
+      "gjon@kutia.net",
+      "endi@kutia.net",
+      "era@kutia.net",
+      "elsa@kutia.net",
+      "rrezart@kutia.net",
     ];
     const slugs = ["test-1", "test-2", "test-3", "test-4"];
 

--- a/src/common/db/seeds/rooms/add-to-room.seed.ts
+++ b/src/common/db/seeds/rooms/add-to-room.seed.ts
@@ -21,10 +21,11 @@ export class AddToRoomSeeder implements Seeder {
       "era@kutia.net",
       "elsa@kutia.net",
       "rrezart@kutia.net",
+      "albi@kutia.net",
     ];
-    const slugs = ["test-1", "test-2", "test-3", "test-4"];
+    const ids = [1, 2, 3, 4];
 
-    const rooms = await roomsRepository.find({ where: { slug: In(slugs) } });
+    const rooms = await roomsRepository.find({ where: { id: In(ids) } });
     const users = await usersRepository.find({ where: { email: In(emails) } });
     const roomUsers: RoomUsers[] = [];
 

--- a/src/common/db/seeds/rooms/create-room.seed.ts
+++ b/src/common/db/seeds/rooms/create-room.seed.ts
@@ -10,10 +10,10 @@ export class RoomsSeeder implements Seeder {
     const roomsRepository = AppDataSource.getRepository(Room);
 
     const rooms = roomsRepository.create([
-      { title: "test", slug: "test-1" },
-      { title: "test", slug: "test-2" },
-      { title: "test", slug: "test-3" },
-      { title: "test", slug: "test-4" },
+      { title: "test-1", slug: "test-1" },
+      { title: "test-2", slug: "test-2" },
+      { title: "test-3", slug: "test-3" },
+      { title: "test-4", slug: "test-4" },
     ]);
 
     await roomsRepository.save(rooms);

--- a/src/common/interfaces/responses/get-rooms.response.ts
+++ b/src/common/interfaces/responses/get-rooms.response.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Room } from "src/api/rooms/entities/room.entity";
+import { Roles } from "src/api/rooms/enums/roles.enum";
+
+export class GetRoomsResponse {
+  @ApiProperty({
+    type: Room,
+    description: "Room object",
+  })
+  room: Room;
+
+  @ApiProperty({
+    enum: Roles,
+    description: "Users role in the corresponding room",
+  })
+  role: Roles;
+}

--- a/src/common/interfaces/responses/room-relations.response.ts
+++ b/src/common/interfaces/responses/room-relations.response.ts
@@ -1,0 +1,50 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Room } from "src/api/rooms/entities/room.entity";
+
+class UserWithRole {
+  @ApiProperty()
+  uuid: string;
+
+  @ApiProperty()
+  firstName: string;
+
+  @ApiProperty()
+  lastName: string;
+
+  @ApiProperty()
+  email: string;
+
+  @ApiProperty()
+  role: string;
+}
+
+class NoteMinimal {
+  @ApiProperty()
+  uuid: string;
+
+  @ApiProperty()
+  content: string;
+
+  @ApiProperty()
+  totalVotes: number;
+
+  @ApiProperty()
+  xAxis: number;
+
+  @ApiProperty()
+  yAxis: number;
+
+  @ApiProperty()
+  created_at: Date;
+
+  @ApiProperty()
+  updated_at: Date;
+}
+
+export class RoomRelationsResponse extends Room {
+  @ApiProperty({ type: UserWithRole, isArray: true })
+  user: UserWithRole[];
+
+  @ApiProperty({ type: NoteMinimal, isArray: true })
+  note: NoteMinimal[];
+}

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -10,5 +10,6 @@ export const slug = (str) => {
     .replace(/[^a-z0-9 -]/g, "")
     .replace(/\s+/g, "-")
     .replace(/-+/g, "-");
-  return str;
+  const timestamp = Date.now();
+  return `${str}-${timestamp}`;
 };


### PR DESCRIPTION
This PR adds:

- Restriction to findRooms to only return current user's rooms 
- Api doc for join room endpoint
- Api docs for room entity
- Uses findWithRelations method in rooms controller
- Updates room and add-to-rooms seed