### PR TITLE
fix: update log out logic in auth controller

### DIFF
--- a/src/api/auth/auth.controller.ts
+++ b/src/api/auth/auth.controller.ts
@@ -21,15 +21,16 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from "@nestjs/swagger";
+import { GetCurrentUser } from "src/common/decorators/get-current-user.decorator";
 import { BadRequestResponse } from "src/common/interfaces/responses/bad-request.response";
 import { ForbiddenResponse } from "src/common/interfaces/responses/forbidden.response";
 import { InternalErrorResponse } from "src/common/interfaces/responses/internal-error.response";
 import { LoginUserResponse } from "src/common/interfaces/responses/login-user.respons";
 import { UnauthorizedResponse } from "src/common/interfaces/responses/unauthorized.response";
 import { UserTokensResponse } from "src/common/interfaces/responses/user-tokens.response";
-import { GetCurrentUserId } from "../../common/decorators/get-current-user-id.decorator";
 import { Public } from "../../common/decorators/public.decorator";
 import { AccessTokenGuard } from "../../common/guards/access-token.guard";
+import { User } from "../user/entities/user.entity";
 import { AuthService } from "./auth.service";
 import { LoginDto } from "./dtos/login.dto";
 import { RefreshTokenDto } from "./dtos/refresh-token.dto";
@@ -90,8 +91,8 @@ export class AuthController implements IAuthController {
   @UseGuards(AccessTokenGuard)
   @Post("logout")
   @HttpCode(HttpStatus.OK)
-  async logout(@GetCurrentUserId() userId: string): Promise<void> {
-    return this.authService.logout(userId);
+  async logout(@GetCurrentUser() user: User): Promise<void> {
+    return this.authService.logout(user.uuid);
   }
 
   @ApiOperation({

--- a/src/api/auth/interfaces/auth.controller.interface.ts
+++ b/src/api/auth/interfaces/auth.controller.interface.ts
@@ -1,3 +1,4 @@
+import { User } from "src/api/user/entities/user.entity";
 import { LoginDto } from "../dtos/login.dto";
 import { RefreshTokenDto } from "../dtos/refresh-token.dto";
 import { RegisterDTO } from "../dtos/register.dto";
@@ -6,6 +7,6 @@ import { Tokens } from "../types";
 export interface IAuthController {
   register: (body: RegisterDTO) => Promise<Tokens>;
   login: (body: LoginDto) => Promise<Tokens>;
-  logout: (user: string) => Promise<void>;
+  logout: (user: User) => Promise<void>;
   refreshToken: (body: RefreshTokenDto) => Promise<Tokens>;
 }

--- a/src/api/user/entities/user.entity.ts
+++ b/src/api/user/entities/user.entity.ts
@@ -76,7 +76,7 @@ export class User extends AuditEntity {
     type: "varchar",
     length: 128,
     nullable: true,
-    name: "hashed_reset_token",
+    name: "hashed_refresh_token",
   })
   @Exclude()
   hashedRefreshToken: string;

--- a/src/common/db/migrations/1746703996135-UpdateUserField.ts
+++ b/src/common/db/migrations/1746703996135-UpdateUserField.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateUserField746703996135 implements MigrationInterface {
+  name = "UpdateUserField1746703996135";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" RENAME COLUMN "hashed_reset_token" TO "hashed_refresh_token"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" RENAME COLUMN "hashed_refresh_token" TO "hashed_reset_token"`,
+    );
+  }
+}


### PR DESCRIPTION
This PR fixes an issue where the user isn't logged due to the ID not being received properly from the decorator.

It also makes a change to the column name going from `hashed_reset_token` -> `hashed_refresh_token`