### PR TITLE
feature: add room-based role guard

### DIFF
--- a/src/api/rooms/entities/room-users.entity.ts
+++ b/src/api/rooms/entities/room-users.entity.ts
@@ -9,7 +9,7 @@ import {
   PrimaryGeneratedColumn,
   Unique,
 } from "typeorm";
-import { Roles } from "../enums/roles.enum";
+import { RoomRoles } from "../enums/room-roles.enum";
 import { Room } from "./room.entity";
 
 @Entity("room_users")
@@ -25,8 +25,8 @@ export class RoomUsers {
   @Column({ name: "user_id", type: "integer" })
   userId: number;
 
-  @Column({ type: "enum", enum: Roles, default: Roles.PARTICIPANT, nullable: false })
-  role: Roles;
+  @Column({ type: "enum", enum: RoomRoles, default: RoomRoles.PARTICIPANT, nullable: false })
+  role: RoomRoles;
 
   @CreateDateColumn()
   joined_at: Date;

--- a/src/api/rooms/enums/room-roles.enum.ts
+++ b/src/api/rooms/enums/room-roles.enum.ts
@@ -1,4 +1,4 @@
-export enum Roles {
+export enum RoomRoles {
   HOST = "host",
   PARTICIPANT = "participant",
 }

--- a/src/api/rooms/interfaces/rooms.controller.interface.ts
+++ b/src/api/rooms/interfaces/rooms.controller.interface.ts
@@ -4,12 +4,12 @@ import { CreateRoomDto } from "../dtos/create-room.dto";
 import { UpdateRoomDto } from "../dtos/update-room.dto";
 import { RoomUsers } from "../entities/room-users.entity";
 import { Room } from "../entities/room.entity";
-import { Roles } from "../enums/roles.enum";
+import { RoomRoles } from "../enums/room-roles.enum";
 
 export interface IRoomsController {
   findById(roomId: string): Promise<Room>;
 
-  findRooms(user: User): Promise<{ room: Room; role: Roles }[]>;
+  findRooms(user: User): Promise<{ room: Room; role: RoomRoles }[]>;
 
   create(body: CreateRoomDto, user: User): Promise<Room>;
 

--- a/src/api/rooms/interfaces/rooms.service.interface.ts
+++ b/src/api/rooms/interfaces/rooms.service.interface.ts
@@ -3,12 +3,12 @@ import { CreateRoomDto } from "../dtos/create-room.dto";
 import { UpdateRoomDto } from "../dtos/update-room.dto";
 import { RoomUsers } from "../entities/room-users.entity";
 import { Room } from "../entities/room.entity";
-import { Roles } from "../enums/roles.enum";
+import { RoomRoles } from "../enums/room-roles.enum";
 
 export interface IRoomsService {
   findById(roomId: string): Promise<Room>;
 
-  findRooms(userId: string): Promise<{ room: Room; role: Roles }[]>;
+  findRooms(userId: string): Promise<{ room: Room; role: RoomRoles }[]>;
 
   createRoom(payload: CreateRoomDto, userId: string): Promise<Room>;
 

--- a/src/api/rooms/rooms.controller.ts
+++ b/src/api/rooms/rooms.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  UseGuards,
 } from "@nestjs/common";
 import {
   ApiBadRequestResponse,
@@ -19,6 +20,8 @@ import {
   ApiUnauthorizedResponse,
 } from "@nestjs/swagger";
 import { GetCurrentUser } from "src/common/decorators/get-current-user.decorator";
+import { Roles } from "src/common/decorators/roles.decorator";
+import { RolesGuard } from "src/common/guards/roles.guard";
 import { IDeleteStatus } from "src/common/interfaces/DeleteStatus.interface";
 import { BadRequestResponse } from "src/common/interfaces/responses/bad-request.response";
 import { DeletedResponse } from "src/common/interfaces/responses/deleted.response";
@@ -31,13 +34,14 @@ import { CreateRoomDto } from "./dtos/create-room.dto";
 import { UpdateRoomDto } from "./dtos/update-room.dto";
 import { RoomUsers } from "./entities/room-users.entity";
 import { Room } from "./entities/room.entity";
-import { Roles } from "./enums/roles.enum";
+import { RoomRoles } from "./enums/room-roles.enum";
 import { IRoomsController } from "./interfaces/rooms.controller.interface";
 import { RoomsService } from "./rooms.service";
 
 @ApiBearerAuth()
 @ApiTags("Rooms")
 @Controller("rooms")
+@UseGuards(RolesGuard)
 export class RoomsController implements IRoomsController {
   constructor(private roomsService: RoomsService) {}
 
@@ -142,6 +146,7 @@ export class RoomsController implements IRoomsController {
     description: "A 401 error if no bearer token is provided",
     type: UnauthorizedResponse,
   })
+  @Roles(RoomRoles.HOST)
   @Delete(":roomId")
   async delete(@Param("roomId", new ParseUUIDPipe()) roomId: string): Promise<IDeleteStatus> {
     return this.roomsService.deleteRoom(roomId);
@@ -180,6 +185,7 @@ export class RoomsController implements IRoomsController {
     return this.roomsService.leaveRoom(uuid, roomId);
   }
 
+  @Roles(RoomRoles.HOST)
   @Post("remove/:roomId")
   async removeFromRoom(
     @Body() body: string,

--- a/src/api/rooms/rooms.controller.ts
+++ b/src/api/rooms/rooms.controller.ts
@@ -80,7 +80,7 @@ export class RoomsController implements IRoomsController {
     type: UnauthorizedResponse,
   })
   @Get()
-  async findRooms(@GetCurrentUser() user: User): Promise<{ room: Room; role: Roles }[]> {
+  async findRooms(@GetCurrentUser() user: User): Promise<{ room: Room; role: RoomRoles }[]> {
     const { uuid } = user;
     return this.roomsService.findRooms(uuid);
   }

--- a/src/api/rooms/rooms.module.ts
+++ b/src/api/rooms/rooms.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
 import { CustomRepositoryModule } from "src/common/db/CustomRepository.module";
 import { UserModule } from "../user/users.module";
 import { RoomUsersRepository } from "./repository/room-users.repository";
@@ -8,11 +8,11 @@ import { RoomsService } from "./rooms.service";
 
 @Module({
   imports: [
-    UserModule,
     CustomRepositoryModule.forCustomRepository([RoomsRepository, RoomUsersRepository]),
+    forwardRef(() => UserModule),
   ],
   controllers: [RoomsController],
-  providers: [RoomsService],
-  exports: [RoomsService],
+  providers: [RoomsService, RoomUsersRepository],
+  exports: [RoomsService, RoomUsersRepository],
 })
 export class RoomsModule {}

--- a/src/api/rooms/rooms.service.ts
+++ b/src/api/rooms/rooms.service.ts
@@ -9,7 +9,7 @@ import { CreateRoomDto } from "./dtos/create-room.dto";
 import { UpdateRoomDto } from "./dtos/update-room.dto";
 import { RoomUsers } from "./entities/room-users.entity";
 import { Room } from "./entities/room.entity";
-import { Roles } from "./enums/roles.enum";
+import { RoomRoles } from "./enums/room-roles.enum";
 import { IRoomsService } from "./interfaces/rooms.service.interface";
 import { RoomUsersRepository } from "./repository/room-users.repository";
 import { RoomsRepository } from "./repository/rooms.repository";
@@ -143,7 +143,7 @@ export class RoomsService implements IRoomsService {
         const room = manager.create(Room, payload);
         const newRoom = await manager.save(Room, room);
 
-        await this.joinRoomInternal(manager, userId, newRoom.uuid, Roles.HOST);
+        await this.joinRoomInternal(manager, userId, newRoom.uuid, RoomRoles.HOST);
 
         return newRoom;
       }),
@@ -213,7 +213,7 @@ export class RoomsService implements IRoomsService {
     manager: EntityManager,
     userId: string,
     roomId: string,
-    role?: Roles,
+    role?: RoomRoles,
   ): Promise<RoomUsers> {
     const [roomUser, error] = await tryCatch(async () => {
       const room = await manager.findOneByOrFail(Room, { uuid: roomId });

--- a/src/api/rooms/rooms.service.ts
+++ b/src/api/rooms/rooms.service.ts
@@ -115,7 +115,7 @@ export class RoomsService implements IRoomsService {
    * @returns Promise that resolves to an array of rooms
    * @throws {InternalServerErrorException} - If there was an error processing the request
    */
-  async findRooms(userId: string): Promise<{ room: Room; role: Roles }[]> {
+  async findRooms(userId: string): Promise<{ room: Room; role: RoomRoles }[]> {
     const [roomUsers, error] = await tryCatch(
       this.roomUsersRepository.find({
         where: { user: { uuid: userId } },

--- a/src/api/user/users.controller.ts
+++ b/src/api/user/users.controller.ts
@@ -27,7 +27,8 @@ import { UnprocessableEntityResponse } from "src/common/interfaces/responses/unp
 import { GetCurrentUser } from "../../common/decorators/get-current-user.decorator";
 import { Public } from "../../common/decorators/public.decorator";
 import { PermissionsGuard } from "../../common/guards/permissions.guard";
-import { RolesGuard } from "../../common/guards/roles.guard";
+import { PaginationInterceptor } from "../../common/interceptors/pagination.interceptor";
+import { CreateUserDto } from "./dtos/create-user.dto";
 import { ForgotPasswordDto, ResetPasswordDto } from "./dtos/password-reset.dto";
 import { UpdateUserDto } from "./dtos/update-user.dto";
 import { User } from "./entities/user.entity";
@@ -40,7 +41,6 @@ import { UsersService } from "./users.service";
 @UsePipes(new ValidationPipe())
 @UseInterceptors(ClassSerializerInterceptor)
 @UseGuards(PermissionsGuard)
-@UseGuards(RolesGuard)
 export class UsersController implements IUsersController {
   constructor(private readonly usersService: UsersService) {}
 

--- a/src/api/user/users.module.ts
+++ b/src/api/user/users.module.ts
@@ -1,6 +1,7 @@
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { CustomRepositoryModule } from "../../common/db/CustomRepository.module";
+import { RoomsModule } from "../rooms/rooms.module";
 import { PasswordReset } from "./entities/reset-password.entity";
 import { UsersRepository } from "./repository/users.repository";
 import { UsersController } from "./users.controller";
@@ -10,6 +11,7 @@ import { UsersService } from "./users.service";
   imports: [
     CustomRepositoryModule.forCustomRepository([UsersRepository]),
     TypeOrmModule.forFeature([PasswordReset]),
+    forwardRef(() => RoomsModule),
   ],
   providers: [UsersService],
   controllers: [UsersController],

--- a/src/common/db/seeds/rooms/add-to-room.seed.ts
+++ b/src/common/db/seeds/rooms/add-to-room.seed.ts
@@ -2,7 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { Seeder } from "nestjs-seeder";
 import { RoomUsers } from "src/api/rooms/entities/room-users.entity";
 import { Room } from "src/api/rooms/entities/room.entity";
-import { Roles } from "src/api/rooms/enums/roles.enum";
+import { RoomRoles } from "src/api/rooms/enums/room-roles.enum";
 import { User } from "src/api/user/entities/user.entity";
 import { In } from "typeorm";
 import AppDataSource from "../../dataSource/data-source.initialize";
@@ -33,8 +33,8 @@ export class AddToRoomSeeder implements Seeder {
       for (const user of users) {
         let ru: RoomUsers;
 
-        if (user.id === 1) ru = roomUsersRepository.create({ role: Roles.HOST });
-        else ru = roomUsersRepository.create({ role: Roles.PARTICIPANT });
+        if (user.id === 1) ru = roomUsersRepository.create({ role: RoomRoles.HOST });
+        else ru = roomUsersRepository.create({ role: RoomRoles.PARTICIPANT });
 
         ru.user = user;
         ru.room = room;

--- a/src/common/guards/delete-note.guard.ts
+++ b/src/common/guards/delete-note.guard.ts
@@ -1,7 +1,7 @@
 import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from "@nestjs/common";
 import { NotesService } from "src/api/notes/notes.service";
 import { RoomUsers } from "src/api/rooms/entities/room-users.entity";
-import { Roles } from "src/api/rooms/enums/roles.enum";
+import { RoomRoles } from "src/api/rooms/enums/room-roles.enum";
 import { User } from "src/api/user/entities/user.entity";
 import { DataSource } from "typeorm";
 
@@ -25,7 +25,7 @@ export class DeleteNoteGuard implements CanActivate {
       where: { roomId: note.room.id, userId: user.id },
     });
 
-    const isHost = roomUser?.role === Roles.HOST;
+    const isHost = roomUser?.role === RoomRoles.HOST;
 
     if (!isAuthor && !isHost) {
       throw new ForbiddenException("You are not allowed to delete this note.");

--- a/src/common/interfaces/responses/get-rooms.response.ts
+++ b/src/common/interfaces/responses/get-rooms.response.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { Room } from "src/api/rooms/entities/room.entity";
-import { Roles } from "src/api/rooms/enums/roles.enum";
+import { RoomRoles } from "src/api/rooms/enums/room-roles.enum";
 
 export class GetRoomsResponse {
   @ApiProperty({
@@ -10,8 +10,8 @@ export class GetRoomsResponse {
   room: Room;
 
   @ApiProperty({
-    enum: Roles,
+    enum: RoomRoles,
     description: "Users role in the corresponding room",
   })
-  role: Roles;
+  role: RoomRoles;
 }


### PR DESCRIPTION
This PR adds a role guard for restricting routes based on whether the user is a host or participant of a specific room.

It also changes the name of the `Roles` enum to `RoomRoles` due to naming conflicts with the `@Roles` decorator for setting role metadata.

### Usage

```js
@Roles(RoomRoles.HOST)
@Get("route")
hostMethod() {
	// Method implementation
}
```