### PR TITLE
refactor: make get comments endpoint return with relations

### DIFF
--- a/src/api/comments/comments.controller.ts
+++ b/src/api/comments/comments.controller.ts
@@ -1,4 +1,14 @@
-import { Controller, Delete, Get, ParseUUIDPipe, Patch, Post, Query } from "@nestjs/common";
+import {
+  ClassSerializerInterceptor,
+  Controller,
+  Delete,
+  Get,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+  UseInterceptors,
+} from "@nestjs/common";
 import {
   ApiBadRequestResponse,
   ApiBearerAuth,
@@ -23,6 +33,7 @@ import { ICommentsController } from "./interfaces/comments.controller.interface"
 @ApiBearerAuth()
 @ApiTags("Comments")
 @Controller("comments")
+@UseInterceptors(ClassSerializerInterceptor)
 export class CommentsController implements ICommentsController {
   constructor(private commentsService: CommentsService) {}
 

--- a/src/api/comments/comments.service.ts
+++ b/src/api/comments/comments.service.ts
@@ -48,7 +48,10 @@ export class CommentsService implements ICommentsService {
     const note = await this.notesService.findById(noteId);
 
     const [comments, error] = await tryCatch(
-      this.commentsRepository.find({ where: { note: { id: note.id } } }),
+      this.commentsRepository.find({
+        where: { note: { id: note.id } },
+        relations: ["user", "parent"],
+      }),
     );
 
     if (error)

--- a/src/common/db/seeds/comments/create-comment.seeder.ts
+++ b/src/common/db/seeds/comments/create-comment.seeder.ts
@@ -1,0 +1,61 @@
+import { Injectable } from "@nestjs/common";
+import { Seeder } from "nestjs-seeder";
+import { Comment } from "src/api/comments/entities/comment.entity";
+import { Note } from "src/api/notes/entities/note.entity";
+import { User } from "src/api/user/entities/user.entity";
+import { In } from "typeorm";
+import AppDataSource from "../../dataSource/data-source.initialize";
+
+@Injectable()
+export class CommentsSeeder implements Seeder {
+  async seed(): Promise<any> {
+    const notesRepository = AppDataSource.getRepository(Note);
+    const commentsRepository = AppDataSource.getRepository(Comment);
+    const usersRepository = AppDataSource.getRepository(User);
+
+    const notes = await notesRepository.find();
+    const users = await usersRepository.find();
+
+    const comments = commentsRepository.create([
+      { note: notes[0], content: "test", user: users[0] },
+      { note: notes[0], content: "test-2", user: users[1] },
+      { note: notes[1], content: "test-3", user: users[3] },
+      { note: notes[1], content: "test-4", user: users[4] },
+      { note: notes[2], content: "test-5", user: users[4] },
+      { note: notes[2], content: "test-6", user: users[2] },
+    ]);
+
+    const createdComments = await commentsRepository.save(comments);
+
+    const replies = commentsRepository.create([
+      {
+        parent: createdComments[0],
+        note: createdComments[0].note,
+        content: "reply to 'test'",
+        user: users[5],
+      },
+      {
+        parent: createdComments[2],
+        note: createdComments[2].note,
+        content: "reply to 'test-3'",
+        user: users[6],
+      },
+      {
+        parent: createdComments[5],
+        note: createdComments[5].note,
+        content: "reply to 'test-6'",
+        user: users[1],
+      },
+    ]);
+
+    await commentsRepository.save(replies);
+  }
+
+  async drop(): Promise<any> {
+    const commentsRepository = AppDataSource.getRepository(Comment);
+
+    const ids = [1, 2, 3, 4, 5, 6];
+
+    await commentsRepository.delete({ id: In(ids) });
+  }
+}

--- a/src/common/db/seeds/seeder.ts
+++ b/src/common/db/seeds/seeder.ts
@@ -2,6 +2,7 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { seeder } from "nestjs-seeder";
 import { DataSourceOptions } from "typeorm";
 import { config } from "../dataSource/data-source.config";
+import { CommentsSeeder } from "./comments/create-comment.seeder";
 import { NotesSeeder } from "./notes/create-notes.seed";
 import { AddToRoomSeeder } from "./rooms/add-to-room.seed";
 import { RoomsSeeder } from "./rooms/create-room.seed";
@@ -9,4 +10,4 @@ import { UsersSeeder } from "./users/create-users.seed";
 
 seeder({
   imports: [TypeOrmModule.forRoot(config as DataSourceOptions)],
-}).run([UsersSeeder, RoomsSeeder, AddToRoomSeeder, NotesSeeder]);
+}).run([UsersSeeder, RoomsSeeder, AddToRoomSeeder, NotesSeeder, CommentsSeeder]);


### PR DESCRIPTION
This PR makes the `/comments?noteId=:nodeId` endpoint return all comments now including their parent comment (if the comment is a reply). It also adds a seeder for creating comments.