### PR TITLE
fix: update RegEx pattern for password reset DTO

### DIFF
--- a/src/api/user/dtos/password-reset.dto.ts
+++ b/src/api/user/dtos/password-reset.dto.ts
@@ -25,7 +25,7 @@ export class ResetPasswordDto {
   })
   @IsString()
   @IsNotEmpty()
-  @Matches(/^(?=.*\d)(?=.*[!@#$%^&*])(?=.*[a-z])(?=.*[A-Z]).{6,15}$/, {
+  @Matches(/^(?=.*\d)(?=.*[!@#$%^&*.?_-])(?=.*[a-z])(?=.*[A-Z]).{8,32}$/, {
     message:
       "Password must be 6 to 15 characters and must contain a letter, a number, a symbol, one upper case and " +
       "lower case character.",


### PR DESCRIPTION
This PR makes the password reset DTO use the same pattern that the register DTO uses for validating passwords.