### PR TITLE
refactor: rename IDeleteStatus interface to IResponseStatus

### DIFF
--- a/src/api/comments/comments.controller.ts
+++ b/src/api/comments/comments.controller.ts
@@ -21,7 +21,7 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from "@nestjs/swagger";
-import { GetCurrentUser } from "src/common/decorators/get-current-user.decorator";
+import { GetCurrentUser } from "../../common/decorators/get-current-user.decorator";
 import { IResponseStatus } from "../../common/interfaces/ResponseStatus.interface";
 import { BadRequestResponse } from "../../common/interfaces/responses/bad-request.response";
 import { DeletedResponse } from "../../common/interfaces/responses/deleted.response";

--- a/src/api/comments/comments.controller.ts
+++ b/src/api/comments/comments.controller.ts
@@ -22,7 +22,7 @@ import {
   ApiUnauthorizedResponse,
 } from "@nestjs/swagger";
 import { GetCurrentUser } from "src/common/decorators/get-current-user.decorator";
-import { IDeleteStatus } from "../../common/interfaces/DeleteStatus.interface";
+import { IResponseStatus } from "../../common/interfaces/ResponseStatus.interface";
 import { BadRequestResponse } from "../../common/interfaces/responses/bad-request.response";
 import { DeletedResponse } from "../../common/interfaces/responses/deleted.response";
 import { NotFoundResponse } from "../../common/interfaces/responses/not-found.response";

--- a/src/api/comments/comments.service.ts
+++ b/src/api/comments/comments.service.ts
@@ -5,7 +5,7 @@ import {
   InternalServerErrorException,
   NotFoundException,
 } from "@nestjs/common";
-import { IDeleteStatus } from "../../common/interfaces/DeleteStatus.interface";
+import { IResponseStatus } from "../../common/interfaces/ResponseStatus.interface";
 import { NotesService } from "../notes/notes.service";
 import { UsersService } from "../user/users.service";
 import { CreateCommentDto } from "./dtos/create-comment.dto";
@@ -133,7 +133,7 @@ export class CommentsService implements ICommentsService {
    * @param commentId - The unique UUID of the comment
    * @throws {NotFoundException} - If no comment with the given UUID is found
    */
-  async deleteComment(commentId: string): Promise<IDeleteStatus> {
+  async deleteComment(commentId: string): Promise<IResponseStatus> {
     const comment = await this.findById(commentId);
 
     const [replies, repliesError] = await tryCatch(

--- a/src/api/comments/interfaces/comments.controller.interface.ts
+++ b/src/api/comments/interfaces/comments.controller.interface.ts
@@ -1,5 +1,5 @@
 import { User } from "src/api/user/entities/user.entity";
-import { IDeleteStatus } from "../../../common/interfaces/DeleteStatus.interface";
+import { IResponseStatus } from "../../../common/interfaces/ResponseStatus.interface";
 import { CreateCommentDto } from "../dtos/create-comment.dto";
 import { UpdateCommentDto } from "../dtos/update-comment.dto";
 import { Comment } from "../entities/comment.entity";
@@ -11,5 +11,5 @@ export interface ICommentsController {
 
   update(user: User, commendId: string, body: UpdateCommentDto): Promise<Comment>;
 
-  delete(commentId: string): Promise<IDeleteStatus>;
+  delete(commentId: string): Promise<IResponseStatus>;
 }

--- a/src/api/comments/interfaces/comments.service.interface.ts
+++ b/src/api/comments/interfaces/comments.service.interface.ts
@@ -1,4 +1,4 @@
-import { IDeleteStatus } from "../../../common/interfaces/DeleteStatus.interface";
+import { IResponseStatus } from "../../../common/interfaces/ResponseStatus.interface";
 import { CreateCommentDto } from "../dtos/create-comment.dto";
 import { UpdateCommentDto } from "../dtos/update-comment.dto";
 import { Comment } from "../entities/comment.entity";
@@ -16,5 +16,5 @@ export interface ICommentsService {
     payload: UpdateCommentDto,
   ): Promise<Comment>;
 
-  deleteComment(commentId: string): Promise<IDeleteStatus>;
+  deleteComment(commentId: string): Promise<IResponseStatus>;
 }

--- a/src/api/notes/interfaces/notes.controller.interface.ts
+++ b/src/api/notes/interfaces/notes.controller.interface.ts
@@ -1,4 +1,4 @@
-import { IDeleteStatus } from "../../../common/interfaces/DeleteStatus.interface";
+import { IResponseStatus } from "../../../common/interfaces/ResponseStatus.interface";
 import { User } from "../../user/entities/user.entity";
 import { CreateNoteDto } from "../dtos/create-note.dto";
 import { UpdateNoteDto } from "../dtos/update-note.dto";
@@ -11,7 +11,7 @@ export interface INotesController {
 
   update(noteId: string, body: UpdateNoteDto, currentUser: User): Promise<Note>;
 
-  delete(noteId: string): Promise<IDeleteStatus>;
+  delete(noteId: string): Promise<IResponseStatus>;
 
   addVote(noteId: string, currentUser: User): Promise<boolean>;
 

--- a/src/api/notes/interfaces/notes.service.interface.ts
+++ b/src/api/notes/interfaces/notes.service.interface.ts
@@ -1,4 +1,4 @@
-import { IDeleteStatus } from "../../../common/interfaces/DeleteStatus.interface";
+import { IResponseStatus } from "../../../common/interfaces/ResponseStatus.interface";
 import { User } from "../../user/entities/user.entity";
 import { CreateNoteDto } from "../dtos/create-note.dto";
 import { UpdateNoteDto } from "../dtos/update-note.dto";
@@ -11,7 +11,7 @@ export interface INotesService {
 
   updateNote(noteId: string, payload: UpdateNoteDto, currentUser: User): Promise<Note>;
 
-  deleteNote(noteId: string): Promise<IDeleteStatus>;
+  deleteNote(noteId: string): Promise<IResponseStatus>;
 
   addVote(noteId: string, currentUser: User): Promise<boolean>;
 

--- a/src/api/notes/notes.controller.ts
+++ b/src/api/notes/notes.controller.ts
@@ -30,7 +30,7 @@ import {
 import { InternalErrorResponse } from "src/common/interfaces/responses/internal-error.response";
 import { GetCurrentUser } from "../../common/decorators/get-current-user.decorator";
 import { DeleteNoteGuard } from "../../common/guards/delete-note.guard";
-import { IDeleteStatus } from "../../common/interfaces/DeleteStatus.interface";
+import { IResponseStatus } from "../../common/interfaces/ResponseStatus.interface";
 import { BadRequestResponse } from "../../common/interfaces/responses/bad-request.response";
 import { DeletedResponse } from "../../common/interfaces/responses/deleted.response";
 import { ForbiddenResponse } from "../../common/interfaces/responses/forbidden.response";
@@ -166,7 +166,9 @@ export class NotesController implements INotesController {
     type: InternalErrorResponse,
   })
   @HttpCode(HttpStatus.OK)
-  async delete(@Param("noteId", new ParseUUIDPipe()) noteId: string): Promise<IDeleteStatus> {
+  async delete(
+    @Param("noteId", new ParseUUIDPipe()) noteId: string,
+  ): Promise<IResponseStatus> {
     return await this.notesService.deleteNote(noteId);
   }
 

--- a/src/api/notes/notes.service.ts
+++ b/src/api/notes/notes.service.ts
@@ -7,7 +7,7 @@ import {
 } from "@nestjs/common";
 
 import { DataSource, EntityManager } from "typeorm";
-import { IDeleteStatus } from "../../common/interfaces/DeleteStatus.interface";
+import { IResponseStatus } from "../../common/interfaces/ResponseStatus.interface";
 import { RoomsService } from "../rooms/rooms.service";
 import { User } from "../user/entities/user.entity";
 import { CreateNoteDto } from "./dtos/create-note.dto";
@@ -175,7 +175,7 @@ export class NotesService implements INotesService {
    * @throws {ForbiddenException} - If the user is not authorized to delete the note
    * @throws {InternalServerErrorException} - If an error occurs while removing the note.
    */
-  async deleteNote(noteId: string): Promise<IDeleteStatus> {
+  async deleteNote(noteId: string): Promise<IResponseStatus> {
     const note = await this.findById(noteId);
 
     try {

--- a/src/api/rooms/interfaces/rooms.controller.interface.ts
+++ b/src/api/rooms/interfaces/rooms.controller.interface.ts
@@ -1,4 +1,4 @@
-import { IDeleteStatus } from "../../../common/interfaces/DeleteStatus.interface";
+import { IResponseStatus } from "../../../common/interfaces/ResponseStatus.interface";
 import { User } from "../../user/entities/user.entity";
 import { CreateRoomDto } from "../dtos/create-room.dto";
 import { UpdateRoomDto } from "../dtos/update-room.dto";
@@ -15,11 +15,11 @@ export interface IRoomsController {
 
   update(roomId: string, body: UpdateRoomDto): Promise<Room>;
 
-  delete(roomId: string): Promise<IDeleteStatus>;
+  delete(roomId: string): Promise<IResponseStatus>;
 
   join(user: User, roomId: string): Promise<RoomUsers>;
 
-  leave(user: User, roomId: string): Promise<IDeleteStatus>;
+  leave(user: User, roomId: string): Promise<IResponseStatus>;
 
-  removeFromRoom(userId: string, roomId: string): Promise<IDeleteStatus>;
+  removeFromRoom(userId: string, roomId: string): Promise<IResponseStatus>;
 }

--- a/src/api/rooms/interfaces/rooms.service.interface.ts
+++ b/src/api/rooms/interfaces/rooms.service.interface.ts
@@ -1,4 +1,4 @@
-import { IDeleteStatus } from "../../../common/interfaces/DeleteStatus.interface";
+import { IResponseStatus } from "../../../common/interfaces/ResponseStatus.interface";
 import { CreateRoomDto } from "../dtos/create-room.dto";
 import { UpdateRoomDto } from "../dtos/update-room.dto";
 import { RoomUsers } from "../entities/room-users.entity";
@@ -14,9 +14,9 @@ export interface IRoomsService {
 
   updateRoom(roomId: string, payload: UpdateRoomDto): Promise<Room>;
 
-  deleteRoom(roomId: string): Promise<IDeleteStatus>;
+  deleteRoom(roomId: string): Promise<IResponseStatus>;
 
   joinRoom(userId: string, roomId: string): Promise<RoomUsers>;
 
-  leaveRoom(userId: string, roomId: string): Promise<IDeleteStatus>;
+  leaveRoom(userId: string, roomId: string): Promise<IResponseStatus>;
 }

--- a/src/api/rooms/rooms.controller.ts
+++ b/src/api/rooms/rooms.controller.ts
@@ -25,7 +25,7 @@ import {
 import { GetCurrentUser } from "../../common/decorators/get-current-user.decorator";
 import { Roles } from "../../common/decorators/roles.decorator";
 import { RolesGuard } from "../../common/guards/roles.guard";
-import { IDeleteStatus } from "../../common/interfaces/DeleteStatus.interface";
+import { IResponseStatus } from "../../common/interfaces/ResponseStatus.interface";
 import { BadRequestResponse } from "../../common/interfaces/responses/bad-request.response";
 import { DeletedResponse } from "../../common/interfaces/responses/deleted.response";
 import { GetRoomsResponse } from "../../common/interfaces/responses/get-rooms.response";
@@ -174,7 +174,9 @@ export class RoomsController implements IRoomsController {
   })
   @Roles(RoomRoles.HOST)
   @Delete(":roomId")
-  async delete(@Param("roomId", new ParseUUIDPipe()) roomId: string): Promise<IDeleteStatus> {
+  async delete(
+    @Param("roomId", new ParseUUIDPipe()) roomId: string,
+  ): Promise<IResponseStatus> {
     return this.roomsService.deleteRoom(roomId);
   }
 
@@ -222,7 +224,7 @@ export class RoomsController implements IRoomsController {
   async leave(
     @GetCurrentUser() user: User,
     @Param("roomId", new ParseUUIDPipe()) roomId: string,
-  ): Promise<IDeleteStatus> {
+  ): Promise<IResponseStatus> {
     const { uuid } = user;
     return this.roomsService.leaveRoom(uuid, roomId);
   }
@@ -248,7 +250,7 @@ export class RoomsController implements IRoomsController {
   async removeFromRoom(
     @Query("userId", new ParseUUIDPipe()) userId: string,
     @Param("roomId", new ParseUUIDPipe()) roomId: string,
-  ): Promise<IDeleteStatus> {
+  ): Promise<IResponseStatus> {
     return this.roomsService.leaveRoom(userId, roomId);
   }
 }

--- a/src/api/rooms/rooms.service.ts
+++ b/src/api/rooms/rooms.service.ts
@@ -1,7 +1,7 @@
 import { tryCatch } from "@maxmorozoff/try-catch-tuple";
 import { Injectable, InternalServerErrorException, NotFoundException } from "@nestjs/common";
 import { DataSource, EntityManager } from "typeorm";
-import { IDeleteStatus } from "../../common/interfaces/DeleteStatus.interface";
+import { IResponseStatus } from "../../common/interfaces/ResponseStatus.interface";
 import { User } from "../user/entities/user.entity";
 import { UsersService } from "../user/users.service";
 import { CreateRoomDto } from "./dtos/create-room.dto";
@@ -121,7 +121,7 @@ export class RoomsService implements IRoomsService {
    * @returns Promise that resolves to a status object indicating success
    * @throws {InternalServerErrorException} - If there was an error processing the request
    */
-  async deleteRoom(roomId: string): Promise<IDeleteStatus> {
+  async deleteRoom(roomId: string): Promise<IResponseStatus> {
     const room = await this.findById(roomId);
 
     const [_, error] = await tryCatch(
@@ -207,7 +207,7 @@ export class RoomsService implements IRoomsService {
    * @returns Promise that resolves to DeleteStatus if successful, false otherwise
    * @throws {InternalServerErrorException} - If there was an error processing the request
    */
-  async leaveRoom(userId: string, roomId: string): Promise<IDeleteStatus> {
+  async leaveRoom(userId: string, roomId: string): Promise<IResponseStatus> {
     const room = await this.findById(roomId);
     const user = await this.usersService.findOne(userId);
 

--- a/src/api/user/dtos/password-reset.dto.ts
+++ b/src/api/user/dtos/password-reset.dto.ts
@@ -3,7 +3,11 @@ import { IsEmail, IsNotEmpty, IsString, Matches } from "class-validator";
 import { SameAs } from "../../../common/decorators/validation.decorator";
 
 export class ForgotPasswordDto {
-  @ApiProperty()
+  @ApiProperty({
+    type: String,
+    description: "User's email address",
+    example: "test@test.com",
+  })
   @IsEmail()
   email: string;
 }

--- a/src/api/user/interfaces/users.controller.interface.ts
+++ b/src/api/user/interfaces/users.controller.interface.ts
@@ -13,7 +13,7 @@ export interface IUsersController {
 
   deleteMe(user: User): Promise<IResponseStatus>;
 
-  forgotPassword(body: ForgotPasswordDto): Promise<void>;
+  forgotPassword(body: ForgotPasswordDto): Promise<IResponseStatus>;
 
   resetPassword(token: string, body: ResetPasswordDto): Promise<void>;
 }

--- a/src/api/user/interfaces/users.controller.interface.ts
+++ b/src/api/user/interfaces/users.controller.interface.ts
@@ -1,4 +1,4 @@
-import { IDeleteStatus } from "src/common/interfaces/DeleteStatus.interface";
+import { IResponseStatus } from "src/common/interfaces/ResponseStatus.interface";
 import { ForgotPasswordDto, ResetPasswordDto } from "../dtos/password-reset.dto";
 import { UpdateUserDto } from "../dtos/update-user.dto";
 import { User } from "../entities/user.entity";
@@ -11,7 +11,7 @@ export interface IUsersController {
 
   updateMe(user: User, body: UpdateUserDto): Promise<User>;
 
-  deleteMe(user: User): Promise<IDeleteStatus>;
+  deleteMe(user: User): Promise<IResponseStatus>;
 
   forgotPassword(body: ForgotPasswordDto): Promise<void>;
 

--- a/src/api/user/interfaces/users.service.interface.ts
+++ b/src/api/user/interfaces/users.service.interface.ts
@@ -18,7 +18,7 @@ export interface IUsersService {
 
   deleteUser(userId: string): Promise<IResponseStatus>;
 
-  forgotPassword(forgotPassword: ForgotPasswordDto): Promise<void>;
+  forgotPassword(forgotPassword: ForgotPasswordDto): Promise<IResponseStatus>;
 
   resetPassword(token: string, resetPasswordDto: ResetPasswordDto): Promise<void>;
 }

--- a/src/api/user/interfaces/users.service.interface.ts
+++ b/src/api/user/interfaces/users.service.interface.ts
@@ -1,7 +1,7 @@
 // remove eslint comment when you start to populate the interface
 
 import { RegisterDTO } from "src/api/auth/dtos/register.dto";
-import { IDeleteStatus } from "src/common/interfaces/DeleteStatus.interface";
+import { IResponseStatus } from "src/common/interfaces/ResponseStatus.interface";
 import { ForgotPasswordDto, ResetPasswordDto } from "../dtos/password-reset.dto";
 import { UpdateUserDto } from "../dtos/update-user.dto";
 import { User } from "../entities/user.entity";
@@ -16,7 +16,7 @@ export interface IUsersService {
 
   updateUser(userId: string, payload: UpdateUserDto): Promise<User>;
 
-  deleteUser(userId: string): Promise<IDeleteStatus>;
+  deleteUser(userId: string): Promise<IResponseStatus>;
 
   forgotPassword(forgotPassword: ForgotPasswordDto): Promise<void>;
 

--- a/src/api/user/users.controller.ts
+++ b/src/api/user/users.controller.ts
@@ -24,7 +24,7 @@ import {
 import { GetCurrentUser } from "../../common/decorators/get-current-user.decorator";
 import { Public } from "../../common/decorators/public.decorator";
 import { PermissionsGuard } from "../../common/guards/permissions.guard";
-import { IDeleteStatus } from "../../common/interfaces/DeleteStatus.interface";
+import { IResponseStatus } from "../../common/interfaces/ResponseStatus.interface";
 import { BadRequestResponse } from "../../common/interfaces/responses/bad-request.response";
 import { DeletedResponse } from "../../common/interfaces/responses/deleted.response";
 import { NotFoundResponse } from "../../common/interfaces/responses/not-found.response";
@@ -126,7 +126,7 @@ export class UsersController implements IUsersController {
     type: NotFoundResponse,
   })
   @Delete("/me")
-  async deleteMe(@GetCurrentUser() user: User): Promise<IDeleteStatus> {
+  async deleteMe(@GetCurrentUser() user: User): Promise<IResponseStatus> {
     return await this.usersService.deleteUser(user.uuid);
   }
 

--- a/src/api/user/users.controller.ts
+++ b/src/api/user/users.controller.ts
@@ -143,7 +143,7 @@ export class UsersController implements IUsersController {
   })
   @Public()
   @Post("forgot")
-  async forgotPassword(@Body() body: ForgotPasswordDto): Promise<void> {
+  async forgotPassword(@Body() body: ForgotPasswordDto): Promise<IResponseStatus> {
     return await this.usersService.forgotPassword(body);
   }
 

--- a/src/api/user/users.controller.ts
+++ b/src/api/user/users.controller.ts
@@ -21,6 +21,7 @@ import {
   ApiTags,
   ApiUnprocessableEntityResponse,
 } from "@nestjs/swagger";
+import { EmailSentResponse } from "src/common/interfaces/responses/email-sent.response";
 import { GetCurrentUser } from "../../common/decorators/get-current-user.decorator";
 import { Public } from "../../common/decorators/public.decorator";
 import { PermissionsGuard } from "../../common/guards/permissions.guard";
@@ -136,6 +137,7 @@ export class UsersController implements IUsersController {
   })
   @ApiOkResponse({
     description: "A 200 response if the email is sent successfully",
+    type: EmailSentResponse,
   })
   @ApiNotFoundResponse({
     description: "A 404 error if the user doesn't exist",

--- a/src/api/user/users.service.ts
+++ b/src/api/user/users.service.ts
@@ -124,9 +124,9 @@ export class UsersService implements IUsersService {
    *
    * @param paload - Required attributes to send a password change request
    * @returns Promise that resolves to void
-   * @throws {UnprocessableEntityException} - If no user is found with the given email
+   * @throws {NotFoundException} - If no user is found with the given email
    */
-  async forgotPassword(paload: ForgotPasswordDto): Promise<void> {
+  async forgotPassword(paload: ForgotPasswordDto): Promise<IResponseStatus> {
     const user = await this.userRepository.findOne({
       where: { email: paload.email },
     });
@@ -157,6 +157,12 @@ export class UsersService implements IUsersService {
       expiresAt,
       user,
     });
+
+    return {
+      success: true,
+      message: "Email sent successfully",
+      timestamp: new Date(),
+    };
   }
 
   /**

--- a/src/api/user/users.service.ts
+++ b/src/api/user/users.service.ts
@@ -9,7 +9,7 @@ import {
 import { InjectRepository } from "@nestjs/typeorm";
 import { InjectEventEmitter } from "nest-emitter";
 import { Repository } from "typeorm";
-import { IDeleteStatus } from "../../common/interfaces/DeleteStatus.interface";
+import { IResponseStatus } from "../../common/interfaces/ResponseStatus.interface";
 import { compareHashedDataBcrypt, hashDataBrypt } from "../../services/providers";
 import { RegisterDTO } from "../auth/dtos/register.dto";
 import { ForgotPasswordDto, ResetPasswordDto } from "./dtos/password-reset.dto";
@@ -106,7 +106,7 @@ export class UsersService implements IUsersService {
    * @param userId - The unique UUID of the user
    * @throws {NotFoundException} - If no user with the given UUID is found
    */
-  async deleteUser(userId: string): Promise<IDeleteStatus> {
+  async deleteUser(userId: string): Promise<IResponseStatus> {
     const user = await this.findOne(userId);
     await this.userRepository.softRemove(user);
 

--- a/src/common/interfaces/ResponseStatus.interface.ts
+++ b/src/common/interfaces/ResponseStatus.interface.ts
@@ -1,9 +1,9 @@
 import { ResourceType } from "../types/ResourceType";
 
-export interface IDeleteStatus {
+export interface IResponseStatus {
   success: boolean;
   message: string;
-  resourceType: ResourceType;
+  resourceType?: ResourceType;
   resourceId?: string;
   timestamp?: Date;
 }

--- a/src/common/interfaces/responses/deleted.response.ts
+++ b/src/common/interfaces/responses/deleted.response.ts
@@ -1,8 +1,8 @@
-import { ApiProperty } from "@nestjs/swagger";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { ResourceType } from "../../types/ResourceType";
-import { IDeleteStatus } from "../DeleteStatus.interface";
+import { IResponseStatus } from "../ResponseStatus.interface";
 
-export class DeletedResponse implements IDeleteStatus {
+export class DeletedResponse implements IResponseStatus {
   @ApiProperty({
     type: Boolean,
     description: "Indicates if the request was successful",
@@ -17,21 +17,21 @@ export class DeletedResponse implements IDeleteStatus {
   })
   message: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     type: String,
     description: "The type of resource that was deleted",
     example: "note",
   })
-  resourceType: ResourceType;
+  resourceType?: ResourceType;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     type: String,
     description: "The unique identifier of the deleted resource",
     example: "123e4567-e89b-12d3-a456-426614174000",
   })
   resourceId?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     type: Date,
     description: "Timestamp of when the deletion occurred",
     example: "2023-10-01T12:00:00Z",

--- a/src/common/interfaces/responses/email-sent.response.ts
+++ b/src/common/interfaces/responses/email-sent.response.ts
@@ -1,0 +1,25 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { IResponseStatus } from "../ResponseStatus.interface";
+
+export class EmailSentResponse implements IResponseStatus {
+  @ApiProperty({
+    type: Boolean,
+    description: "Indicates if the request was successful",
+    example: true,
+  })
+  success: boolean;
+
+  @ApiProperty({
+    type: String,
+    description: "Message indicating the status of the email",
+    example: "Email sent successfully",
+  })
+  message: string;
+
+  @ApiPropertyOptional({
+    type: Date,
+    description: "Timestamp of when the email was sent",
+    example: "2023-10-01T12:00:00Z",
+  })
+  timestamp?: Date;
+}


### PR DESCRIPTION
This PR:

- Changes the `/users/forgot` endpoint return a custom status with a success value and message.
- Adds better documentation to the `/users/forgot` endpoint for both the DTO and response type.
- Renames the `IDeleteStatus` interface to `IResponseStatus`, to be more generic so that it can be used in other cases of custom return values.