### PR TITLE
refactor: use IResponseStatus in signup & resend code endpoints

### DIFF
--- a/src/api/auth/auth.controller.ts
+++ b/src/api/auth/auth.controller.ts
@@ -23,6 +23,7 @@ import {
   ApiUnauthorizedResponse,
   ApiUnprocessableEntityResponse,
 } from "@nestjs/swagger";
+import { IResponseStatus } from "src/common/interfaces/ResponseStatus.interface";
 import { GetCurrentUser } from "../../common/decorators/get-current-user.decorator";
 import { Public } from "../../common/decorators/public.decorator";
 import { AccessTokenGuard } from "../../common/guards/access-token.guard";
@@ -67,7 +68,7 @@ export class AuthController implements IAuthController {
   @Public()
   @Post("register")
   @HttpCode(HttpStatus.CREATED)
-  async register(@Body() registerDto: RegisterDTO): Promise<Tokens> {
+  async register(@Body() registerDto: RegisterDTO): Promise<IResponseStatus> {
     return await this.authService.signup(registerDto);
   }
 
@@ -168,7 +169,9 @@ export class AuthController implements IAuthController {
   @Public()
   @Post("resend-verification/:email")
   @HttpCode(HttpStatus.OK)
-  async resendVerifyEmail(@Param("email", EmailValidationPipe) email: string): Promise<void> {
+  async resendVerifyEmail(
+    @Param("email", EmailValidationPipe) email: string,
+  ): Promise<IResponseStatus> {
     return this.authService.sendVerificationEmail(email);
   }
 }

--- a/src/api/auth/auth.controller.ts
+++ b/src/api/auth/auth.controller.ts
@@ -23,10 +23,10 @@ import {
   ApiUnauthorizedResponse,
   ApiUnprocessableEntityResponse,
 } from "@nestjs/swagger";
-import { IResponseStatus } from "src/common/interfaces/ResponseStatus.interface";
 import { GetCurrentUser } from "../../common/decorators/get-current-user.decorator";
 import { Public } from "../../common/decorators/public.decorator";
 import { AccessTokenGuard } from "../../common/guards/access-token.guard";
+import { IResponseStatus } from "../../common/interfaces/ResponseStatus.interface";
 import { BadRequestResponse } from "../../common/interfaces/responses/bad-request.response";
 import { ForbiddenResponse } from "../../common/interfaces/responses/forbidden.response";
 import { InternalErrorResponse } from "../../common/interfaces/responses/internal-error.response";

--- a/src/api/auth/auth.service.ts
+++ b/src/api/auth/auth.service.ts
@@ -259,7 +259,7 @@ export class AuthService implements IAuthService {
    * @param userId - The unique UUID of the user
    * @returns Promise that resolves to the access and refresh tokens
    */
-  async getTokens(userId: string): Promise<Tokens> {
+  private async getTokens(userId: string): Promise<Tokens> {
     const jwtPayload: JwtPayload = {
       id: userId,
     };
@@ -284,12 +284,12 @@ export class AuthService implements IAuthService {
   /**
    * Generates a verification code for a user and saves it in the database
    *
-   * @param userId - The unique UUID of the user
+   * @param user - The user object who requests the verification code
    * @returns Promise that resolves to the generated verification code
    *
    * @throws {InternalServerErrorException} - If there was an error generating the verification code
    */
-  async generateVerificationCode(user: User): Promise<number> {
+  private async generateVerificationCode(user: User): Promise<number> {
     const code = crypto.randomInt(100000, 999999);
 
     const expiresAt = new Date();

--- a/src/api/auth/auth.service.ts
+++ b/src/api/auth/auth.service.ts
@@ -13,8 +13,9 @@ import {
 import { JwtService } from "@nestjs/jwt";
 import { InjectRepository } from "@nestjs/typeorm";
 import { InjectEventEmitter } from "nest-emitter";
-import { IResponseStatus } from "src/common/interfaces/ResponseStatus.interface";
 import { Repository } from "typeorm";
+import { ResourceType } from "../../common/enums/resource-type.enum";
+import { IResponseStatus } from "../../common/interfaces/ResponseStatus.interface";
 import {
   compareHashedDataArgon,
   compareHashedDataBcrypt,
@@ -77,7 +78,7 @@ export class AuthService implements IAuthService {
       success: true,
       message: "User registered successfully. Please verify your email.",
       resourceId: user.uuid,
-      resourceType: "user",
+      resourceType: ResourceType.USER,
       timestamp: new Date(),
     };
   }
@@ -129,7 +130,7 @@ export class AuthService implements IAuthService {
       success: true,
       message: "Email sent successfully. Please check your inbox.",
       resourceId: user.uuid,
-      resourceType: "user",
+      resourceType: ResourceType.USER,
       timestamp: new Date(),
     };
   }

--- a/src/api/auth/auth.service.ts
+++ b/src/api/auth/auth.service.ts
@@ -113,11 +113,11 @@ export class AuthService implements IAuthService {
   /**
    * Sends a verification email to the user with a verification code
    *
-   * @param userId - The unique UUID of the user
+   * @param email - The unique email of the user
    * @throws {BadRequestException} - If user does not exist or is already verified
    */
-  async sendVerificationEmail(userId: string): Promise<IResponseStatus> {
-    const user = await this.validateUser(userId, {
+  async sendVerificationEmail(email: string): Promise<IResponseStatus> {
+    const user = await this.validateUser(email, {
       isVerified: false,
       message: "User does not exist or is already verified",
     });

--- a/src/api/auth/interfaces/auth.controller.interface.ts
+++ b/src/api/auth/interfaces/auth.controller.interface.ts
@@ -1,3 +1,4 @@
+import { IResponseStatus } from "../../../common/interfaces/ResponseStatus.interface";
 import { User } from "../../user/entities/user.entity";
 import { LoginDto } from "../dtos/login.dto";
 import { RefreshTokenDto } from "../dtos/refresh-token.dto";
@@ -5,8 +6,9 @@ import { RegisterDTO } from "../dtos/register.dto";
 import { Tokens } from "../types";
 
 export interface IAuthController {
-  register: (body: RegisterDTO) => Promise<Tokens>;
+  register: (body: RegisterDTO) => Promise<IResponseStatus>;
   login: (body: LoginDto) => Promise<Tokens>;
   logout: (user: User) => Promise<void>;
   refreshToken: (body: RefreshTokenDto) => Promise<Tokens>;
+  resendVerifyEmail: (userId: string) => Promise<IResponseStatus>;
 }

--- a/src/api/auth/interfaces/auth.service.interface.ts
+++ b/src/api/auth/interfaces/auth.service.interface.ts
@@ -11,5 +11,5 @@ export interface IAuthService {
   logout: (user: string) => Promise<void>;
   refreshToken: (payoad: RefreshTokenDto) => Promise<Tokens>;
   verifyEmail(email: string, code: number): Promise<TTokensUser>;
-  sendVerificationEmail(userId: string): Promise<IResponseStatus>;
+  sendVerificationEmail(email: string): Promise<IResponseStatus>;
 }

--- a/src/api/auth/interfaces/auth.service.interface.ts
+++ b/src/api/auth/interfaces/auth.service.interface.ts
@@ -1,4 +1,4 @@
-import { IResponseStatus } from "src/common/interfaces/ResponseStatus.interface";
+import { IResponseStatus } from "../../../common/interfaces/ResponseStatus.interface";
 import { LoginDto } from "../dtos/login.dto";
 import { RefreshTokenDto } from "../dtos/refresh-token.dto";
 import { RegisterDTO } from "../dtos/register.dto";

--- a/src/api/auth/interfaces/auth.service.interface.ts
+++ b/src/api/auth/interfaces/auth.service.interface.ts
@@ -1,11 +1,15 @@
+import { IResponseStatus } from "src/common/interfaces/ResponseStatus.interface";
 import { LoginDto } from "../dtos/login.dto";
 import { RefreshTokenDto } from "../dtos/refresh-token.dto";
 import { RegisterDTO } from "../dtos/register.dto";
 import { Tokens } from "../types/tokens.types";
+import { TTokensUser } from "../types/user-tokens.type";
 
 export interface IAuthService {
-  signup: (payload: RegisterDTO) => Promise<Tokens>;
+  signup: (payload: RegisterDTO) => Promise<IResponseStatus>;
   login: (payload: LoginDto) => Promise<Tokens>;
   logout: (user: string) => Promise<void>;
   refreshToken: (payoad: RefreshTokenDto) => Promise<Tokens>;
+  verifyEmail(email: string, code: number): Promise<TTokensUser>;
+  sendVerificationEmail(userId: string): Promise<IResponseStatus>;
 }

--- a/src/api/comments/comments.controller.ts
+++ b/src/api/comments/comments.controller.ts
@@ -137,7 +137,7 @@ export class CommentsController implements ICommentsController {
   @Delete(":commentId")
   async delete(
     @Param("commentId", new ParseUUIDPipe()) commentid: string,
-  ): Promise<IDeleteStatus> {
+  ): Promise<IResponseStatus> {
     return this.commentsService.deleteComment(commentid);
   }
 }

--- a/src/api/comments/comments.controller.ts
+++ b/src/api/comments/comments.controller.ts
@@ -24,6 +24,7 @@ import {
 } from "@nestjs/swagger";
 import { GetCurrentUser } from "../../common/decorators/get-current-user.decorator";
 import { RolesGuard } from "../../common/guards/roles.guard";
+import { IResponseStatus } from "../../common/interfaces/ResponseStatus.interface";
 import { BadRequestResponse } from "../../common/interfaces/responses/bad-request.response";
 import { DeletedResponse } from "../../common/interfaces/responses/deleted.response";
 import { NotFoundResponse } from "../../common/interfaces/responses/not-found.response";


### PR DESCRIPTION
This PR changes the return type of endpoints:

- `/auth/register` - from Tokens to IResponseStatus
- `/auth/resend-verification/:email` - from void to IResponseStatus

It also adds an extra touch to auth service, making two inner methods private.