### PR TITLE
feature: add endpoint for exporting data

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 		"express-basic-auth": "^1.2.1",
 		"handlebars": "^4.7.7",
 		"jsonwebtoken": "^9.0.2",
+		"jspdf": "^3.0.1",
 		"multer": "^1.4.5-lts.1",
 		"nest-emitter": "^1.1.1",
 		"nest-winston": "^1.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
+      jspdf:
+        specifier: ^3.0.1
+        version: 3.0.1
       multer:
         specifier: ^1.4.5-lts.1
         version: 1.4.5-lts.2
@@ -1063,6 +1066,9 @@ packages:
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
 
+  '@types/raf@3.4.3':
+    resolution: {integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==}
+
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
@@ -1086,6 +1092,9 @@ packages:
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
@@ -1380,6 +1389,11 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  atob@2.1.2:
+    resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
+    engines: {node: '>= 4.5.0'}
+    hasBin: true
+
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1411,6 +1425,10 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1467,6 +1485,11 @@ packages:
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
 
+  btoa@1.2.1:
+    resolution: {integrity: sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==}
+    engines: {node: '>= 0.4.0'}
+    hasBin: true
+
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
@@ -1516,6 +1539,10 @@ packages:
 
   caniuse-lite@1.0.30001720:
     resolution: {integrity: sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==}
+
+  canvg@3.0.11:
+    resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
+    engines: {node: '>=10.0.0'}
 
   chalk@3.0.0:
     resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
@@ -1737,6 +1764,9 @@ packages:
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
 
+  core-js@3.43.0:
+    resolution: {integrity: sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -1781,6 +1811,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   css-select@5.1.0:
     resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
@@ -1937,6 +1970,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.2.6:
+    resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -2243,6 +2279,9 @@ packages:
   fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -2486,6 +2525,10 @@ packages:
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
+
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
 
   htmlparser2@5.0.1:
     resolution: {integrity: sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==}
@@ -2912,6 +2955,9 @@ packages:
   jsonwebtoken@9.0.2:
     resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
     engines: {node: '>=12', npm: '>=6'}
+
+  jspdf@3.0.1:
+    resolution: {integrity: sha512-qaGIxqxetdoNnFQQXxTKUD9/Z7AloLaw94fFsOiJMxbfYdBbrBuhWmbzI8TVjrw7s3jBY1PFHofBKMV/wZPapg==}
 
   jstransformer@1.0.0:
     resolution: {integrity: sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==}
@@ -3639,6 +3685,9 @@ packages:
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+
   pg-cloudflare@1.2.5:
     resolution: {integrity: sha512-OOX22Vt0vOSRrdoUPKJ8Wi2OpE/o/h9T8X1s4qSkCedbNah9ei2W2765be8iMVxQUsvgT7zIAT2eIa9fs5+vtg==}
 
@@ -3816,6 +3865,9 @@ packages:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
     engines: {node: '>=8'}
 
+  raf@3.4.1:
+    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
+
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
@@ -3868,6 +3920,9 @@ packages:
   reflect-metadata@0.1.14:
     resolution: {integrity: sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==}
 
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
   relateurl@0.2.7:
     resolution: {integrity: sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==}
     engines: {node: '>= 0.10'}
@@ -3919,6 +3974,10 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rgbcolor@1.0.1:
+    resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
+    engines: {node: '>= 0.8.15'}
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
@@ -4133,6 +4192,10 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  stackblur-canvas@2.7.0:
+    resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
+    engines: {node: '>=0.1.14'}
+
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
@@ -4224,6 +4287,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svg-pathdata@6.0.3:
+    resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
+    engines: {node: '>=12.0.0'}
+
   swagger-ui-dist@4.18.2:
     resolution: {integrity: sha512-oVBoBl9Dg+VJw8uRWDxlyUyHoNEDC0c1ysT6+Boy6CTgr2rUcLcfPon4RvxgS2/taNW6O0+US+Z/dlAsWFjOAQ==}
 
@@ -4270,6 +4337,9 @@ packages:
 
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
+
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -4527,6 +4597,9 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -5816,6 +5889,9 @@ snapshots:
 
   '@types/qs@6.14.0': {}
 
+  '@types/raf@3.4.3':
+    optional: true
+
   '@types/range-parser@1.2.7': {}
 
   '@types/semver@7.7.0': {}
@@ -5845,6 +5921,9 @@ snapshots:
       '@types/superagent': 8.1.9
 
   '@types/triple-beam@1.3.5': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/uuid@10.0.0': {}
 
@@ -6174,6 +6253,8 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  atob@2.1.2: {}
+
   babel-jest@29.7.0(@babel/core@7.27.3):
     dependencies:
       '@babel/core': 7.27.3
@@ -6234,6 +6315,9 @@ snapshots:
       '@babel/types': 7.27.3
 
   balanced-match@1.0.2: {}
+
+  base64-arraybuffer@1.0.2:
+    optional: true
 
   base64-js@1.5.1: {}
 
@@ -6323,6 +6407,8 @@ snapshots:
     dependencies:
       node-int64: 0.4.0
 
+  btoa@1.2.1: {}
+
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
@@ -6371,6 +6457,18 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001720: {}
+
+  canvg@3.0.11:
+    dependencies:
+      '@babel/runtime': 7.27.3
+      '@types/raf': 3.4.3
+      core-js: 3.43.0
+      raf: 3.4.1
+      regenerator-runtime: 0.13.11
+      rgbcolor: 1.0.1
+      stackblur-canvas: 2.7.0
+      svg-pathdata: 6.0.3
+    optional: true
 
   chalk@3.0.0:
     dependencies:
@@ -6598,6 +6696,9 @@ snapshots:
 
   cookiejar@2.1.4: {}
 
+  core-js@3.43.0:
+    optional: true
+
   core-util-is@1.0.3: {}
 
   cors@2.8.5:
@@ -6659,6 +6760,11 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
 
   css-select@5.1.0:
     dependencies:
@@ -6774,6 +6880,11 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.2.6:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+    optional: true
 
   domutils@2.8.0:
     dependencies:
@@ -7157,6 +7268,8 @@ snapshots:
 
   fecha@4.2.3: {}
 
+  fflate@0.8.2: {}
+
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -7454,6 +7567,12 @@ snapshots:
       dom-serializer: 2.0.0
       htmlparser2: 8.0.2
       selderee: 0.11.0
+
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+    optional: true
 
   htmlparser2@5.0.1:
     dependencies:
@@ -8081,6 +8200,18 @@ snapshots:
       lodash.once: 4.1.1
       ms: 2.1.3
       semver: 7.7.2
+
+  jspdf@3.0.1:
+    dependencies:
+      '@babel/runtime': 7.27.3
+      atob: 2.1.2
+      btoa: 1.2.1
+      fflate: 0.8.2
+    optionalDependencies:
+      canvg: 3.0.11
+      core-js: 3.43.0
+      dompurify: 3.2.6
+      html2canvas: 1.4.1
 
   jstransformer@1.0.0:
     dependencies:
@@ -8988,6 +9119,9 @@ snapshots:
 
   peberminta@0.9.0: {}
 
+  performance-now@2.1.0:
+    optional: true
+
   pg-cloudflare@1.2.5:
     optional: true
 
@@ -9183,6 +9317,11 @@ snapshots:
 
   quick-lru@4.0.1: {}
 
+  raf@3.4.1:
+    dependencies:
+      performance-now: 2.1.0
+    optional: true
+
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -9256,6 +9395,9 @@ snapshots:
 
   reflect-metadata@0.1.14: {}
 
+  regenerator-runtime@0.13.11:
+    optional: true
+
   relateurl@0.2.7: {}
 
   require-directory@2.1.1: {}
@@ -9295,6 +9437,9 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rgbcolor@1.0.1:
+    optional: true
 
   rimraf@3.0.2:
     dependencies:
@@ -9549,6 +9694,9 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  stackblur-canvas@2.7.0:
+    optional: true
+
   statuses@2.0.1: {}
 
   streamsearch@1.1.0: {}
@@ -9638,6 +9786,9 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svg-pathdata@6.0.3:
+    optional: true
+
   swagger-ui-dist@4.18.2: {}
 
   symbol-observable@4.0.0: {}
@@ -9678,6 +9829,11 @@ snapshots:
   text-extensions@1.9.0: {}
 
   text-hex@1.0.0: {}
+
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
 
   text-table@0.2.0: {}
 
@@ -9881,6 +10037,11 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
+    optional: true
 
   uuid@11.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ onlyBuiltDependencies:
   - '@nestjs/core'
   - argon2
   - bcrypt
+  - core-js

--- a/src/api/notes/dtos/export-notes.dto.ts
+++ b/src/api/notes/dtos/export-notes.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsEnum, IsNotEmpty, IsUUID } from "class-validator";
+import { ExportFileType } from "../enums/export-file-type.enum";
+
+export class ExportNotesDto {
+  @ApiProperty({
+    description: "The UUID of the room from which notes are to be exported",
+    type: String,
+    example: "123e4567-e89b-12d3-a456-426614174000",
+  })
+  @IsNotEmpty()
+  @IsUUID()
+  roomId: string;
+
+  @ApiProperty({
+    description: "The format in which notes should be exported",
+    enum: ExportFileType,
+    example: ExportFileType.JSON,
+  })
+  @IsNotEmpty()
+  @IsEnum(ExportFileType)
+  fileType: ExportFileType;
+}

--- a/src/api/notes/enums/export-file-type.enum.ts
+++ b/src/api/notes/enums/export-file-type.enum.ts
@@ -1,0 +1,6 @@
+export enum ExportFileType {
+  XML = "xml",
+  JSON = "json",
+  CSV = "csv",
+  PDF = "pdf",
+}

--- a/src/api/notes/interfaces/exported-file.interface.ts
+++ b/src/api/notes/interfaces/exported-file.interface.ts
@@ -1,0 +1,5 @@
+export interface IExportedFile {
+  buffer: Buffer;
+  filename: string;
+  mimeType: string;
+}

--- a/src/api/notes/notes.controller.ts
+++ b/src/api/notes/notes.controller.ts
@@ -27,7 +27,10 @@ import {
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
+  ApiUnprocessableEntityResponse,
 } from "@nestjs/swagger";
+import { Response } from "express";
+import { UnprocessableEntityResponse } from "src/common/interfaces/responses/unprocessable-entity.response";
 import { GetCurrentUser } from "../../common/decorators/get-current-user.decorator";
 import { RolesGuard } from "../../common/guards/roles.guard";
 import { IResponseStatus } from "../../common/interfaces/ResponseStatus.interface";
@@ -250,6 +253,31 @@ export class NotesController implements INotesController {
   ): Promise<IRemoveVoteNote> {
     return await this.notesService.removeVote(noteId, currentUser);
   }
+
+  @ApiOperation({
+    summary: "Export notes",
+    description:
+      "Exports all notes from a specific room in the requested format (JSON, CSV, or Markdown). Returns a file download",
+  })
+  @ApiOkResponse({
+    description: "A 200 response with the exported notes file",
+  })
+  @ApiBadRequestResponse({
+    description: "A 400 error if the export format is invalid",
+    type: BadRequestResponse,
+  })
+  @ApiUnauthorizedResponse({
+    description: "A 401 error if no bearer token is provided",
+    type: UnauthorizedResponse,
+  })
+  @ApiNotFoundResponse({
+    description: "A 404 error if the room is not found",
+    type: NotFoundResponse,
+  })
+  @ApiUnprocessableEntityResponse({
+    description: "A 422 error if there are no notes to export",
+    type: UnprocessableEntityResponse,
+  })
   @Get("export")
   async exportNotes(@Query() query: ExportNotesDto, @Res() res: Response) {
     const { buffer, filename, mimeType } = await this.notesService.exportNotes(query);

--- a/src/api/notes/notes.controller.ts
+++ b/src/api/notes/notes.controller.ts
@@ -11,6 +11,7 @@ import {
   Patch,
   Post,
   Query,
+  Res,
   UseGuards,
   UseInterceptors,
 } from "@nestjs/common";
@@ -38,6 +39,7 @@ import { NotFoundResponse } from "../../common/interfaces/responses/not-found.re
 import { UnauthorizedResponse } from "../../common/interfaces/responses/unauthorized.response";
 import { User } from "../user/entities/user.entity";
 import { CreateNoteDto } from "./dtos/create-note.dto";
+import { ExportNotesDto } from "./dtos/export-notes.dto";
 import { UpdateNoteDto } from "./dtos/update-note.dto";
 import { Note } from "./entities/note.entity";
 import { IAddVoteNote, IRemoveVoteNote } from "./interfaces/notes-response.interface";
@@ -247,5 +249,17 @@ export class NotesController implements INotesController {
     @GetCurrentUser() currentUser: User,
   ): Promise<IRemoveVoteNote> {
     return await this.notesService.removeVote(noteId, currentUser);
+  }
+  @Get("export")
+  async exportNotes(@Query() query: ExportNotesDto, @Res() res: Response) {
+    const { buffer, filename, mimeType } = await this.notesService.exportNotes(query);
+
+    res.set({
+      "Content-Type": mimeType,
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Content-Length": buffer.length,
+    });
+
+    res.end(buffer);
   }
 }

--- a/src/api/notes/notes.controller.ts
+++ b/src/api/notes/notes.controller.ts
@@ -257,7 +257,7 @@ export class NotesController implements INotesController {
   @ApiOperation({
     summary: "Export notes",
     description:
-      "Exports all notes from a specific room in the requested format (JSON, CSV, or Markdown). Returns a file download",
+      "Exports all notes from a specific room in the requested format (JSON, CSV, XML, or PDF). Returns a file to be downloaded.",
   })
   @ApiOkResponse({
     description: "A 200 response with the exported notes file",

--- a/src/api/notes/notes.module.ts
+++ b/src/api/notes/notes.module.ts
@@ -5,6 +5,7 @@ import { RoomsModule } from "../rooms/rooms.module";
 import { NoteVote } from "./entities/note-vote.entity";
 import { NotesController } from "./notes.controller";
 import { NotesService } from "./notes.service";
+import { ParsingProvider } from "./providers/parsing.provider";
 import { NotesRepository } from "./repository/notes.repository";
 
 @Module({
@@ -14,7 +15,7 @@ import { NotesRepository } from "./repository/notes.repository";
     RoomsModule,
   ],
   controllers: [NotesController],
-  providers: [NotesService],
+  providers: [NotesService, ParsingProvider],
   exports: [NotesService],
 })
 export class NotesModule {}

--- a/src/api/notes/notes.service.ts
+++ b/src/api/notes/notes.service.ts
@@ -372,9 +372,15 @@ export class NotesService implements INotesService {
         throw new BadRequestException(`Unsupported file type: ${fileType}`);
     }
 
+    const timestamp = new Date()
+      .toISOString()
+      .replace(/T/, "_")
+      .replace(/\..+/, "")
+      .replace(/:/g, "-");
+
     return {
-      filename: `notes-export-${new Date().toISOString().split("T")[0]}.${fileType}`,
       buffer: Buffer.from(content, fileType === "pdf" ? "base64" : "utf-8"),
+      filename: `notes-export-${timestamp}.${fileType}`,
       mimeType: mime,
     };
   }

--- a/src/api/notes/notes.service.ts
+++ b/src/api/notes/notes.service.ts
@@ -121,6 +121,7 @@ export class NotesService implements INotesService {
       .leftJoinAndSelect("note.noteVotes", "noteVote")
       .leftJoinAndSelect("noteVote.user", "user")
       .where("note.room_id = :roomId", { roomId: room.id })
+      .orderBy("note.totalVotes", "DESC")
       .getMany();
 
     return notes;

--- a/src/api/notes/notes.service.ts
+++ b/src/api/notes/notes.service.ts
@@ -3,21 +3,26 @@ import {
   Injectable,
   InternalServerErrorException,
   NotFoundException,
+  UnprocessableEntityException,
 } from "@nestjs/common";
 
 import { DataSource, EntityManager } from "typeorm";
 import { ResourceType } from "../../common/enums/resource-type.enum";
 import { IResponseStatus } from "../../common/interfaces/ResponseStatus.interface";
 import { Comment } from "../comments/entities/comment.entity";
+import { Room } from "../rooms/entities/room.entity";
 import { RoomsService } from "../rooms/rooms.service";
 import { User } from "../user/entities/user.entity";
 import { catchKnownErrors } from "./../../utils/catchKnownErrors.util";
 import { CreateNoteDto } from "./dtos/create-note.dto";
+import { ExportNotesDto } from "./dtos/export-notes.dto";
 import { UpdateNoteDto } from "./dtos/update-note.dto";
 import { NoteVote } from "./entities/note-vote.entity";
 import { Note } from "./entities/note.entity";
+import { IExportedFile } from "./interfaces/exported-file.interface";
 import { IAddVoteNote, IRemoveVoteNote } from "./interfaces/notes-response.interface";
 import { INotesService } from "./interfaces/notes.service.interface";
+import { ParsingProvider } from "./providers/parsing.provider";
 import { NotesRepository } from "./repository/notes.repository";
 
 @Injectable()
@@ -26,6 +31,7 @@ export class NotesService implements INotesService {
     private readonly dataSource: DataSource,
     private readonly notesRepository: NotesRepository,
     private readonly roomsService: RoomsService,
+    private readonly parsingProvider: ParsingProvider,
   ) {}
 
   /**
@@ -313,5 +319,59 @@ export class NotesService implements INotesService {
         "An error occurred while removing the vote from the note",
       );
     }
+  }
+
+  /**
+   * Exports notes from a specific room in the requested file format.
+   *
+   * @param query - The export request containing room ID and file type
+   * @returns A Promise that resolves to an object that satisfies the IExportedFile interface
+   * @throws {UnprocessableEntityException} - If the room has no notes to export
+   * @throws {BadRequestException} - If the requested file type is unsupported
+   */
+  async exportNotes(query: ExportNotesDto): Promise<IExportedFile> {
+    const room = await this.roomsService.findById(query.roomId);
+    const notes = await this.findNotesWithVotesFromRoom(query.roomId);
+
+    if (!notes || notes.length === 0)
+      throw new UnprocessableEntityException("Room doesn't have any notes to export");
+
+    return this.exportData(room, notes, query.fileType);
+  }
+
+  /**
+   * Exports notes data in the specified format based on MIME type.
+   *
+   * @param room - The room from which notes are being exported
+   * @param notes - The notes to be exported
+   * @param fileType - The file type that determines the export format
+   * @returns An object containing the content as a Buffer, filename, and MIME type
+   */
+  private exportData(room: Room, notes: Note[], fileType: string): IExportedFile {
+    let content: string;
+    let mime: string;
+
+    switch (fileType) {
+      case "json":
+        content = this.parsingProvider.parseJson(room, notes);
+        mime = "application/json";
+        break;
+      case "csv":
+        content = this.parsingProvider.parseCSV(notes);
+        mime = "text/csv";
+        break;
+      case "xml":
+        content = this.parsingProvider.parseXML(room, notes);
+        mime = "application/xml";
+        break;
+      default:
+        throw new BadRequestException(`Unsupported file type: ${fileType}`);
+    }
+
+    return {
+      buffer: Buffer.from(content, "utf8"),
+      filename: `notes-export-${new Date().toISOString().split("T")[0]}.${fileType}`,
+      mimeType: mime,
+    };
   }
 }

--- a/src/api/notes/notes.service.ts
+++ b/src/api/notes/notes.service.ts
@@ -364,13 +364,17 @@ export class NotesService implements INotesService {
         content = this.parsingProvider.parseXML(room, notes);
         mime = "application/xml";
         break;
+      case "pdf":
+        content = this.parsingProvider.parsePDF(room, notes);
+        mime = "application/pdf";
+        break;
       default:
         throw new BadRequestException(`Unsupported file type: ${fileType}`);
     }
 
     return {
-      buffer: Buffer.from(content, "utf8"),
       filename: `notes-export-${new Date().toISOString().split("T")[0]}.${fileType}`,
+      buffer: Buffer.from(content, fileType === "pdf" ? "base64" : "utf-8"),
       mimeType: mime,
     };
   }

--- a/src/api/notes/providers/parsing.provider.ts
+++ b/src/api/notes/providers/parsing.provider.ts
@@ -1,4 +1,5 @@
 import { Injectable } from "@nestjs/common";
+import jsPDF from "jspdf";
 import { Room } from "../../rooms/entities/room.entity";
 import { Note } from "../entities/note.entity";
 
@@ -104,5 +105,70 @@ export class ParsingProvider {
       .replace(/>/g, "&gt;")
       .replace(/"/g, "&quot;")
       .replace(/'/g, "&#39;");
+  }
+
+  /**
+   * Generates a PDF buffer from the notes data.
+   *
+   * @param room - The room from which notes are being exported
+   * @param notes - The notes to be converted to PDF format
+   * @returns A Buffer containing the PDF data
+   */
+  parsePDF(room: Room, notes: Note[]): string {
+    const doc = new jsPDF();
+
+    // Set up the document
+    doc.setFontSize(20);
+    doc.text(`Exported data for "${room.title}"`, 20, 20);
+
+    doc.setFontSize(12);
+    doc.text(`Exported on: ${new Date().toLocaleDateString()}`, 20, 35);
+    doc.text(`Total Notes: ${notes.length}`, 20, 45);
+
+    // Add a line separator
+    doc.line(20, 55, 190, 55);
+
+    let yPosition = 70;
+    const pageHeight = doc.internal.pageSize.height;
+    const marginBottom = 30;
+
+    notes.forEach((note, index) => {
+      // Check if we need a new page
+      if (yPosition > pageHeight - marginBottom) {
+        doc.addPage();
+        yPosition = 20;
+      }
+
+      // Note header (using note content)
+      doc.setFontSize(13);
+      doc.setFont(undefined, "bold");
+
+      const content = note.content || "No content";
+      const maxWidth = 170;
+      const contentLines = doc.splitTextToSize(content, maxWidth);
+
+      doc.text(contentLines, 20, yPosition);
+      yPosition += contentLines.length * 6;
+
+      // Author and votes info
+      doc.setFontSize(10);
+      doc.setFont(undefined, "normal");
+
+      yPosition += 5;
+      const author = `${note.author.firstName} ${note.author.lastName}`;
+      doc.text(`Author: ${author}`, 20, yPosition);
+      yPosition += 7;
+      doc.text(`Votes: ${note.totalVotes}`, 20, yPosition);
+      yPosition += 7;
+
+      // Add separator line between notes
+      if (index < notes.length - 1) {
+        yPosition += 5;
+        doc.line(20, yPosition, 190, yPosition);
+        yPosition += 10;
+      }
+    });
+
+    return doc.output("datauristring").split(",")[1];
   }
 }

--- a/src/api/notes/providers/parsing.provider.ts
+++ b/src/api/notes/providers/parsing.provider.ts
@@ -1,0 +1,108 @@
+import { Injectable } from "@nestjs/common";
+import { Room } from "../../rooms/entities/room.entity";
+import { Note } from "../entities/note.entity";
+
+@Injectable()
+export class ParsingProvider {
+  /**
+   * Parses notes data into a JSON format suitable for export.
+   *
+   * @param room - The room from which notes are being exported
+   * @param data - The notes data to be parsed
+   * @returns An object containing the room title, export date, and parsed notes
+   */
+  parseJson(room: Room, data: Note[]): string {
+    const parsedNotes = data.map((el) => {
+      return {
+        content: el.content,
+        author: `${el.author.firstName} ${el.author.lastName}`,
+        votes: el.totalVotes,
+        xAxis: el.xAxis,
+        yAxis: el.yAxis,
+      };
+    });
+
+    return JSON.stringify(
+      {
+        room: room.title,
+        exportedAt: new Date(),
+        notes: parsedNotes,
+      },
+      null,
+      2,
+    );
+  }
+
+  /**
+   * Generates a CSV string from the notes data.
+   *
+   * @param notes - The notes to be converted to CSV format
+   * @returns A string representing the notes in CSV format
+   */
+  parseCSV(notes: Note[]): string {
+    const headers = "Content,Author,Votes,X Axis,Y Axis";
+
+    const rows = notes.map((note) => {
+      const content = `${note.content}`;
+      const author = `${note.author.firstName} ${note.author.lastName}`;
+      const votes = note.totalVotes;
+      const xAxis = note.xAxis;
+      const yAxis = note.yAxis;
+
+      return `${content},${author},${votes},${xAxis},${yAxis}`;
+    });
+
+    return [headers, ...rows].join("\n");
+  }
+
+  /**
+   * Generates an XML string from the notes data.
+   *
+   * @param room - The room from which notes are being exported
+   * @param notes - The notes to be converted to XML format
+   * @returns A string representing the notes in XML format
+   */
+  parseXML(room: Room, notes: Note[]): string {
+    const escapedRoomTitle = this.escapeXml(room.title);
+    const exportedAt = new Date().toISOString();
+
+    let xml = `<?xml version="1.0" encoding="UTF-8"?>\n`;
+    xml += "<export>\n";
+    xml += `  <room>${escapedRoomTitle}</room>\n`;
+    xml += `  <exportedAt>${exportedAt}</exportedAt>\n`;
+    xml += "  <notes>\n";
+
+    for (const note of notes) {
+      const content = this.escapeXml(note.content);
+      const author = this.escapeXml(`${note.author.firstName} ${note.author.lastName}`);
+
+      xml += "    <note>\n";
+      xml += `      <content>${content}</content>\n`;
+      xml += `      <author>${author}</author>\n`;
+      xml += `      <votes>${note.totalVotes}</votes>\n`;
+      xml += `      <xAxis>${note.xAxis}</xAxis>\n`;
+      xml += `      <yAxis>${note.yAxis}</yAxis>\n`;
+      xml += "    </note>\n";
+    }
+
+    xml += "  </notes>\n";
+    xml += "</export>";
+
+    return xml;
+  }
+
+  /**
+   * Escapes special characters in a string to make it safe for XML output.
+   *
+   * @param unsafe - The string to be escaped
+   * @returns A string with special characters replaced by their XML-safe equivalents
+   */
+  private escapeXml(unsafe: string): string {
+    return unsafe
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+}


### PR DESCRIPTION
This PR adds the endpoint `/notes/export` for downloading files with notes data. It has two query parameters:

- `roomId` - the room whose data you want to export
- `fileType` - the type of file to export the data as