### PR TITLE
feature: add tracking event for note updates

### DIFF
--- a/src/websocket/interfaces/notes-events.interface.ts
+++ b/src/websocket/interfaces/notes-events.interface.ts
@@ -15,4 +15,6 @@ export interface NotesEmitEvents {
   "notes/deleted": (note: IResponseStatus) => void;
   "notes/voted": (note) => void;
   "notes/removed": (note) => void;
+  "notes/editing-started": (note) => void;
+  "notes/editing-stoped": (note) => void;
 }

--- a/src/websocket/notes.gateway.ts
+++ b/src/websocket/notes.gateway.ts
@@ -173,4 +173,23 @@ export class NotesGateway extends BaseWebsocketGateway {
       socket.emit("error", error.message);
     }
   }
+
+  @SubscribeMessage("notes/editing-start")
+  async handelEditStart(
+    @MessageBody() data: { roomId: string; noteId: string; userId: string; firstName: string },
+    @ConnectedSocket() socket: Socket,
+  ) {
+    const { roomId } = data;
+
+    this.server.to(roomId).emit("notes/editing-started", data);
+  }
+
+  @SubscribeMessage("notes/editing-stop")
+  async handelEditStop(
+    @MessageBody() data: { roomId: string; noteId: string; userId: string; firstName: string },
+    @ConnectedSocket() socket: Socket,
+  ) {
+    const { roomId } = data;
+    this.server.to(roomId).emit("notes/editing-stoped", data);
+  }
 }


### PR DESCRIPTION
This PR add two event to notes gateway to broadcast when a note is being edited by a user.